### PR TITLE
Handle opening, cancelling and failing of downloads

### DIFF
--- a/ui/download-row.ui
+++ b/ui/download-row.ui
@@ -63,7 +63,29 @@
             </child>
           </object>
         </child>
-      </object>
+        <child>
+          <object class="GtkButton" id="open">
+            <property name="focus-on-click">no</property>
+            <property name="relief">none</property>
+            <property name="valign">center</property>
+            <property name="visible">no</property>
+            <child>
+              <object class="GtkImage">
+                <property name="icon-name">document-open-symbolic</property>
+                <property name="use-fallback">yes</property>
+                <property name="visible">yes</property>
+              </object>
+            </child>
+          </object>
+        </child>
+         <child>
+          <object class="GtkImage" id="error">
+            <property name="icon-name">error-symbolic</property>
+            <property name="use-fallback">yes</property>
+            <property name="visible">no</property>
+          </object>
+        </child>
+       </object>
     </child>
   </template>
 </interface>


### PR DESCRIPTION
Cancel cancels a download, Open opens the file, and an error icon is shown if something went wrong.

![screenshot from 2018-07-25 16-59-22](https://user-images.githubusercontent.com/1204189/43209127-36d4314a-902c-11e8-98e8-42a07f48d575.png)