### PR TITLE
Implement a context menu for tab labels

### DIFF
--- a/ui/menus.ui
+++ b/ui/menus.ui
@@ -53,4 +53,18 @@
       </item>
     </section>
   </menu>
+  <menu id="tally-menu">
+    <section>
+      <item>
+        <attribute name="action">tally.pin</attribute>
+        <attribute name="hidden-when">action-disabled</attribute>
+        <attribute name="label" translatable="yes">_Pin Tab</attribute>
+      </item>
+      <item>
+        <attribute name="action">tally.unpin</attribute>
+        <attribute name="hidden-when">action-disabled</attribute>
+        <attribute name="label" translatable="yes">Unpin Ta_b</attribute>
+      </item>
+    </section>
+  </menu>
 </interface>


### PR DESCRIPTION
Initial context menu for tab labels (tallies) with the ability to (un)pin tabs.

![screenshot from 2018-07-30 23-41-33](https://user-images.githubusercontent.com/1204189/43425225-34ac80fa-9452-11e8-9deb-8d38962f2cfb.png)
