### PR TITLE
More consistent handling of Tab.item and Tab.create

### DIFF
--- a/core/browser.vala
+++ b/core/browser.vala
@@ -223,7 +223,9 @@ namespace Midori {
         }
 
         void tab_new_activated () {
-            add (new Tab (tab, web_context));
+            var tab = new Tab (tab, web_context);
+            add (tab);
+            tabs.visible_child = tab;
         }
 
         void tab_close_activated () {
@@ -238,7 +240,7 @@ namespace Midori {
             uint index = trash.get_n_items ();
             if (index > 0) {
                 var item = trash.get_object (index - 1) as DatabaseItem;
-                add (new Tab (tab, web_context, item.uri));
+                add (new Tab (tab, web_context, item.uri, item.title));
                 trash.remove (index - 1);
             }
         }
@@ -325,8 +327,12 @@ namespace Midori {
 
         public new void add (Tab tab) {
             tab.create.connect ((action) => {
-                var new_tab = new Tab (tab, web_context, action.get_request ().uri);
-                add (new_tab);
+                var new_tab = new Tab (tab, web_context);
+                new_tab.hide ();
+                new_tab.ready_to_show.connect (() => {
+                    new_tab.show ();
+                    add (new_tab);
+                });
                 return new_tab;
             });
             tab.enter_fullscreen.connect (() => {

--- a/core/tally.vala
+++ b/core/tally.vala
@@ -43,9 +43,14 @@ namespace Midori {
         Gtk.Button close;
 
         public Tally (Tab tab) {
-            Object (tab: tab, uri: tab.display_uri, title: tab.display_title, visible: tab.visible);
+            Object (tab: tab,
+                    uri: tab.display_uri,
+                    title: tab.display_title,
+                    tooltip_text: tab.display_title,
+                    visible: tab.visible);
             tab.bind_property ("display-uri", this, "uri");
             tab.bind_property ("display-title", this, "title");
+            tab.bind_property ("display-title", this, "tooltip-text");
             tab.bind_property ("visible", this, "visible");
             close.clicked.connect (() => { tab.try_close (); });
             tab.notify["is-loading"].connect ((pspec) => {


### PR DESCRIPTION
* create normally loads a given request and emits ready_to_show, so we should support this and emulate the same behavior when emitting create.
* a new browser tab should get focus.
* Tab.item should be set in the case of a delayed load.
* tooltips should always be set for the tally.