### PR TITLE
Provide app menu fallback in the form of a button

### DIFF
--- a/core/app.vala
+++ b/core/app.vala
@@ -85,6 +85,11 @@ namespace Midori {
             var action = new SimpleAction ("win-new", VariantType.STRING);
             action.activate.connect (win_new_activated);
             add_action (action);
+
+            // Unset app menu if not handled by the shell
+            if (!Gtk.Settings.get_default ().gtk_shell_shows_app_menu){
+                app_menu = null;
+            }
         }
 
         void win_new_activated (Action action, Variant? parameter) {

--- a/core/browser.vala
+++ b/core/browser.vala
@@ -41,6 +41,8 @@ namespace Midori {
         [GtkChild]
         Gtk.MenuButton profile;
         [GtkChild]
+        Gtk.MenuButton app_menu;
+        [GtkChild]
         Gtk.Image profile_icon;
         [GtkChild]
         Gtk.ActionBar navigationbar;
@@ -110,6 +112,11 @@ namespace Midori {
                 menubutton.menu_model = application.get_menu_by_id ("browser-menu");
 
                 application.bind_busy_property (this, "is-loading");
+                // App menu fallback as a button rather than a menu
+                if (!Gtk.Settings.get_default ().gtk_shell_shows_app_menu) {
+                    app_menu.menu_model = application.get_menu_by_id ("app-menu");
+                    app_menu.show ();
+                }
             });
 
             // Action for switching tabs via Alt+number

--- a/ui/browser.ui
+++ b/ui/browser.ui
@@ -44,6 +44,22 @@
           </packing>
         </child>
         <child>
+          <object class="GtkMenuButton" id="app_menu">
+            <property name="focus-on-click">no</property>
+            <property name="valign">center</property>
+            <child>
+              <object class="GtkImage">
+                <property name="icon-name">view-more-symbolic</property>
+                <property name="use-fallback">yes</property>
+                <property name="visible">yes</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="pack-type">end</property>
+          </packing>
+        </child>
+         <child>
           <object class="GtkMenuButton" id="profile">
             <property name="focus-on-click">no</property>
             <property name="valign">center</property>


### PR DESCRIPTION
If the window manger doesn't advertise support for an "app menu", such as the menu shown in the top right under GNOME Shell, GTK+ adds the menu to the menubar of the window. A menu button seems a much better choice.