### PR TITLE
Implement speed dial based on recent history

### DIFF
--- a/core/tab.vala
+++ b/core/tab.vala
@@ -55,7 +55,7 @@ namespace Midori {
             get_settings ().enable_developer_extras = true;
 
             if (pinned) {
-                load_uri (uri ?? "about:blank");
+                load_uri (uri ?? "internal:speed-dial");
                 Plugins.get_default ().plug (this);
             } else {
                 load_uri_delayed.begin (uri, title);
@@ -63,7 +63,7 @@ namespace Midori {
         }
 
         async void load_uri_delayed (string? uri, string? title) {
-            display_uri = uri ?? "about:blank";
+            display_uri = uri ?? "internal:speed-dial";
             display_title = title ?? display_uri;
             item = new DatabaseItem (display_uri, display_title, 0);
 

--- a/core/urlbar.vala
+++ b/core/urlbar.vala
@@ -35,7 +35,7 @@ namespace Midori {
             }
             primary_icon_activatable = !blank;
         } }
-        bool blank { get { return uri == "about:blank"; } }
+        bool blank { get { return uri == "about:blank" || uri == "internal:speed-dial"; } }
 
         [GtkChild]
         Gtk.Popover? suggestions;
@@ -164,7 +164,7 @@ namespace Midori {
                     complete ();
                     return true;
                 case Gdk.Key.Escape:
-                    text = uri;
+                    text = blank ? "" : uri;
                     // Propagate to allow Escape to stop loading
                     return false;
             }

--- a/data/about.css
+++ b/data/about.css
@@ -71,3 +71,53 @@ button {
     font-size: 14pt;
     text-align: right;
 }
+
+#grid {
+    margin: auto auto;
+}
+
+.shortcut {
+    width: 27%;
+    max-width: 32%;
+    height: 30%;
+    margin: 1%;
+    display: inline-table;
+    box-sizing: border-box;
+    overflow: hidden;
+}
+
+.shortcut a {
+    width: 100%;
+    height: 100%;
+    display: block;
+    text-decoration: none;
+}
+
+.shortcut a img {
+    width: 50%;
+    height: 50%;
+    margin: auto;
+    margin-bottom: .5em;
+    display: block;
+    border-radius: 12px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.12),
+                0 1px 2px rgba(0,0,0,0.24);
+}
+
+.shortcut a:hover img {
+    box-shadow: 0 3px 5px rgba(0,0,0,0.24),
+                0 3px 4px rgba(0,0,0,0.48);
+}
+
+.shortcut a .title {
+    width: 90%;
+    color: #222222;
+    text-align: center;
+    text-overflow: ellipsis;
+    word-wrap: nowrap;
+    max-height: 2em;
+    line-height: 1em;
+    overflow: hidden;
+    display: block;
+    font-size: 70%;
+}

--- a/data/speed-dial.html
+++ b/data/speed-dial.html
@@ -1,0 +1,24 @@
+<!--
+ Copyright (C) 2018 Christian Dywan <christian@twotoats.de>
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+
+ See the file COPYING for the full license text.
+-->
+<html>
+  <head>
+    <title>{title}</title>
+    <link ref="shortcut icon" href="stock:///{icon}" />
+    <style type="text/css">
+      {stylesheet}
+    </style>
+  </head>
+  <body>
+    <div id="grid">
+      {content}
+    </div>
+  </body>
+</html>

--- a/gresource.xml
+++ b/gresource.xml
@@ -13,6 +13,7 @@
   <gresource prefix="/">
     <file compressed="true">data/about.css</file>
     <file compressed="true">data/error.html</file>
+    <file compressed="true">data/speed-dial.html</file>
     <file compressed="true">data/gtk3.css</file>
     <file compressed="true">data/logo-shade.svg</file>
     <file compressed="true">data/history/Create.sql</file>


### PR DESCRIPTION
![screenshot from 2018-08-18 20-45-09](https://user-images.githubusercontent.com/1204189/44302400-03a58a80-a328-11e8-8c4f-88be485e7920.png)
The speed dial is implemented as an "internal" scheme handler, which won't require special-casing on the UX side except using "internal:speed-dial" as a default URI in Midori.Tab and recognizing it as "empty" in Midori.Urlbar.
All items are populated automatically from the history and use favicons.