### PR TITLE
Use ContextMenuItem with Gtk.Action as of 2.16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ vala_require("0.30.0")
 set(VALAFLAGS ${VALAFLAGS}
     --debug
     --target-glib=2.48
+    --enable-deprecated
     )
 
 include(GNUInstallDirs)
@@ -50,7 +51,7 @@ set(PKGS sqlite3 gio-2.0 libsoup-2.4)
 
 pkg_check_modules(DEPS_GTK REQUIRED
                   gtk+-3.0>=3.12.0
-                  webkit2gtk-4.0>=2.18
+                  webkit2gtk-4.0>=2.16.6
                   gcr-ui-3>=2.32
                   libpeas-gtk-1.0
                   )

--- a/core/tab.vala
+++ b/core/tab.vala
@@ -192,19 +192,19 @@ namespace Midori {
             if (hit.context_is_link () && !hit.link_uri.has_prefix ("javascript:")) {
                 menu.append (new WebKit.ContextMenuItem.from_stock_action_with_label (WebKit.ContextMenuAction.OPEN_LINK_IN_NEW_WINDOW, _("Open Link in New _Tab")));
                 if (!App.incognito) {
-                    var action = new SimpleAction ("link-window", VariantType.STRING);
+                    var action = new Gtk.Action ("link-window", _("Open Link in New _Window"), null, null);
                     action.activate.connect (() => {
                         var browser = new Browser ((App)Application.get_default ());
                         browser.add (new Tab (null, browser.web_context, hit.link_uri));
                     });
-                    menu.append (new WebKit.ContextMenuItem.from_gaction (action, _("Open Link in New _Window"), hit.link_uri));
+                    menu.append (new WebKit.ContextMenuItem (action));
                 }
-                var action = new SimpleAction ("link-incognito", VariantType.STRING);
+                var action = new Gtk.Action ("link-incognito", _("Open Link in New _Private Window"), null, null);
                 action.activate.connect (() => {
                     var browser = new Browser.incognito ((App)Application.get_default ());
                     browser.add (new Tab (null, browser.web_context, hit.link_uri));
                 });
-                menu.append (new WebKit.ContextMenuItem.from_gaction (action, _("Open Link in New _Private Window"), hit.link_uri));
+                menu.append (new WebKit.ContextMenuItem (action));
                 menu.append (new WebKit.ContextMenuItem.separator ());
                 menu.append (new WebKit.ContextMenuItem.from_stock_action (WebKit.ContextMenuAction.DOWNLOAD_LINK_TO_DISK));
                 menu.append (new WebKit.ContextMenuItem.from_stock_action (WebKit.ContextMenuAction.COPY_LINK_TO_CLIPBOARD));
@@ -226,15 +226,14 @@ namespace Midori {
                 // Selected text, ellipsized if > 32 characters
                 string? text = Gtk.Clipboard.get_for_display (get_display (), Gdk.SELECTION_PRIMARY).wait_for_text ();
                 string? label = ((text != null && text.length > 32) ? text.substring (0, 32) + "…" : text).delimit ("\n", ' ');
-                var action = new SimpleAction ("text-search", VariantType.STRING);
+                var action = new Gtk.Action ("text-search", _("Search %s for \"%s\"").printf ("DuckDuckGo", label), null, null);
                 action.activate.connect (() => {
                     // Allow DuckDuckGo to distinguish Midori and in turn share revenue
                     string uri = "https://duckduckgo.com/?q=%s&t=midori".printf (Uri.escape_string (text, ":/", true));
                     var tab = new Tab (this, web_context, uri);
                     ((Browser)get_toplevel ()).add (tab);
                 });
-                menu.append (new WebKit.ContextMenuItem.from_gaction (
-                    action, _("Search %s for \"%s\"").printf ("DuckDuckGo", label), text));
+                menu.append (new WebKit.ContextMenuItem (action));
             }
             if (clear) {
                 menu.append (new WebKit.ContextMenuItem.separator ());

--- a/vapi/webkit2gtk-4.0.vapi
+++ b/vapi/webkit2gtk-4.0.vapi
@@ -98,6 +98,8 @@ namespace WebKit {
 	[CCode (cheader_filename = "webkit2/webkit2.h", type_id = "webkit_context_menu_item_get_type ()")]
 	public class ContextMenuItem : GLib.InitiallyUnowned {
 		[CCode (has_construct_function = false)]
+		public ContextMenuItem (Gtk.Action action);
+		[CCode (has_construct_function = false)]
 		public ContextMenuItem.from_gaction (GLib.Action action, string label, GLib.Variant? target);
 		[CCode (has_construct_function = false)]
 		public ContextMenuItem.from_stock_action (WebKit.ContextMenuAction action);


### PR DESCRIPTION
By using WebKit.ContextMenuItem with Gtk.Action we can lower the minimum WebKit required from 2.18 to 2.16.