### PR TITLE
Check for availability of xmllint

### DIFF
--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -1,5 +1,10 @@
 # Copyright (C) 2013-2018 Christian Dywan <christian@twotoasts.de>
 
+find_program (XMLLINT_EXECUTABLE xmllint)
+if (NOT XMLLINT_EXECUTABLE)
+    message(FATAL_ERROR "xmllint not found")
+endif ()
+
 include(FindIntltool)
 if (NOT INTLTOOL_MERGE_FOUND)
     message(FATAL_ERROR "intltool-merge not found")

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -72,6 +72,7 @@ parts:
       - libsqlite3-dev
       - intltool
       - ninja-build
+      - libxml2-utils # xmllint
     stage-packages:
       - libwebkit2gtk-4.0-37
       - libgcr-base-3-1


### PR DESCRIPTION
xmllint is used by the gresource compiler to reduce whitespace if `xml-stripblanks` is specified.