### PR TITLE
Implement (help-)--execute interface

### DIFF
--- a/core/browser.vala
+++ b/core/browser.vala
@@ -239,12 +239,12 @@ namespace Midori {
         }
 
         public Browser (App app) {
-            Object (application: app, visible: true,
+            Object (application: app,
                     web_context: WebKit.WebContext.get_default ());
         }
 
         public Browser.incognito (App app) {
-            Object (application: app, visible: true,
+            Object (application: app,
                     web_context: new WebKit.WebContext.ephemeral ());
 
             profile.sensitive = false;

--- a/core/tab.vala
+++ b/core/tab.vala
@@ -212,6 +212,7 @@ namespace Midori {
                     action.activate.connect (() => {
                         var browser = new Browser ((App)Application.get_default ());
                         browser.add (new Tab (null, browser.web_context, hit.link_uri));
+                        browser.show ();
                     });
                     menu.append (new WebKit.ContextMenuItem (action));
                 }
@@ -219,6 +220,7 @@ namespace Midori {
                 action.activate.connect (() => {
                     var browser = new Browser.incognito ((App)Application.get_default ());
                     browser.add (new Tab (null, browser.web_context, hit.link_uri));
+                    browser.show ();
                 });
                 menu.append (new WebKit.ContextMenuItem (action));
                 menu.append (new WebKit.ContextMenuItem.separator ());


### PR DESCRIPTION
For scripting purposes `-execute`, or `-e` for short, exposes actions from the browser window on the command line. `--help-execute` accordingly lists the known actions.

Example:

    midori -e tab-new

Fixes: #31 