### PR TITLE
Replace filler in Clear Private Data with actual text

### DIFF
--- a/ui/clear-private-data.ui
+++ b/ui/clear-private-data.ui
@@ -26,7 +26,7 @@
         <property name="margin">12</property>
         <child>
           <object class="GtkLabel">
-            <property name="label" translatable="yes">Lorem ipsum dolor sit amet</property>
+            <property name="label" translatable="yes">Clear the following data:</property>
             <property name="visible">yes</property>
           </object>
         </child>


### PR DESCRIPTION
The corresponding label was clearly overlooked before. Easy fix.