### PR TITLE
Use full pathname for Icon in .desktop for snap

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,8 @@ add_custom_target (uninstall
 
 install(FILES COPYING README DESTINATION ${CMAKE_INSTALL_DOCDIR})
 
+set(DESKTOP_ICON "${CMAKE_PROJECT_NAME}" CACHE STRING "The Icon value to be used in the .desktop file")
+
 add_subdirectory (core)
 add_subdirectory (web)
 enable_testing()

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -18,6 +18,13 @@ list(REMOVE_ITEM DATA_FILES "CMakeLists.txt")
 foreach(FILE ${DATA_FILES})
     if (${FILE} MATCHES ".desktop")
         if (NOT WIN32)
+            FILE(READ ${CMAKE_CURRENT_SOURCE_DIR}/${FILE} CONTENT)
+            # Escape CMake list-separator ";" first
+            string(REPLACE ";" "\\;" CONTENT "${CONTENT}")
+            string(REPLACE "Icon=${CMAKE_PROJECT_NAME}"
+                           "Icon=${DESKTOP_ICON}"
+                           CONTENT "${CONTENT}")
+            FILE(WRITE ${FILE} ${CONTENT})
             string(REPLACE ".desktop.in" "" DESKTOP_ID ${FILE})
             INTLTOOL_MERGE_DESKTOP (${DESKTOP_ID} po)
         endif ()

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -62,6 +62,7 @@ parts:
     plugin: cmake
     configflags:
       - -DCMAKE_INSTALL_DATADIR=/usr/share
+      - -DDESKTOP_ICON=/usr/share/icons/hicolor/scalable/apps/midori.svg
     build-packages:
       - git
       - valac


### PR DESCRIPTION
This change adds a `DESKTOP_ICON` variable in CMake to customize the value of `Icon` in the `.desktop` file, which in the case of the snap should be an absolute filename.