### PR TITLE
Implement fullscreen mode

### DIFF
--- a/core/navigationbar.vala
+++ b/core/navigationbar.vala
@@ -1,0 +1,33 @@
+/*
+ Copyright (C) 2018 Christian Dywan <christian@twotoats.de>
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+
+ See the file COPYING for the full license text.
+*/
+
+namespace Midori {
+    [GtkTemplate (ui = "/ui/navigationbar.ui")]
+    public class Navigationbar : Gtk.ActionBar {
+        [GtkChild]
+        public Gtk.Button go_back;
+        [GtkChild]
+        public Gtk.Button go_forward;
+        [GtkChild]
+        public Gtk.Button reload;
+        [GtkChild]
+        public Gtk.Button stop_loading;
+        [GtkChild]
+        public Urlbar urlbar;
+        [GtkChild]
+        public Gtk.MenuButton menubutton;
+        [GtkChild]
+        public Gtk.Button restore;
+
+        construct {
+        }
+    }
+}

--- a/gresource.xml
+++ b/gresource.xml
@@ -23,6 +23,7 @@
     <file compressed="true" preprocess="xml-stripblanks">ui/clear-private-data.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/download-button.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/download-row.ui</file>
+    <file compressed="true" preprocess="xml-stripblanks">ui/navigationbar.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/network-check.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/suggestion-row.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/tab.ui</file>

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -12,6 +12,7 @@ core/favicon.vala
 core/history.vala
 core/loggable.vala
 core/main.vala
+core/navigationbar.vala
 core/network-check.vala
 core/shortcuts.val
 core/statusbar.vala
@@ -25,6 +26,7 @@ ui/clear-private-data.ui
 ui/download-button.ui
 ui/download-row.ui
 ui/menus.ui
+ui/navigationbar.ui
 ui/network-check.ui
 ui/shortcuts.ui
 ui/suggestion-row.ui

--- a/ui/browser.ui
+++ b/ui/browser.ui
@@ -11,7 +11,7 @@
     <property name="mode">horizontal</property>
     <widgets>
       <widget name="scrolled"/>
-      <widget name="urlbar"/>
+      <widget name="navigationbar"/>
     </widgets>
   </object>
   <template class="MidoriBrowser" parent="GtkApplicationWindow">
@@ -53,6 +53,23 @@
                   </object>
                 </child>
               </object>
+            </child>
+            <child>
+              <object class="GtkButton">
+                <property name="focus-on-click">no</property>
+                <property name="valign">center</property>
+                <property name="action-name">win.fullscreen</property>
+                <property name="visible">yes</property>
+                <child>
+                  <object class="GtkImage">
+                    <property name="icon-name">view-fullscreen-symbolic</property>
+                    <property name="visible">yes</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="pack-type">end</property>
+              </packing>
             </child>
             <child>
               <object class="MidoriDownloadButton" id="downloads">
@@ -152,88 +169,8 @@
                 <property name="orientation">vertical</property>
                 <property name="visible">yes</property>
                 <child>
-                  <object class="GtkActionBar" id="navigationbar">
+                  <object class="MidoriNavigationbar" id="navigationbar">
                     <property name="visible">yes</property>
-                      <child>
-                        <object class="GtkBox">
-                          <property name="orientation">horizontal</property>
-                          <property name="visible">yes</property>
-                          <style>
-                            <class name="linked"/>
-                          </style>
-                          <child>
-                            <object class="GtkButton" id="go_back">
-                              <property name="focus-on-click">no</property>
-                              <property name="action-name">win.go-back</property>
-                              <property name="visible">yes</property>
-                              <child>
-                                <object class="GtkImage">
-                                  <property name="icon-name">go-previous-symbolic</property>
-                                  <property name="visible">yes</property>
-                                </object>
-                              </child>
-                            </object>
-                          </child>
-                        <child>
-                          <object class="GtkButton" id="go_forward">
-                            <property name="focus-on-click">no</property>
-                            <property name="action-name">win.go-forward</property>
-                            <property name="visible">yes</property>
-                            <child>
-                              <object class="GtkImage">
-                                <property name="icon-name">go-next-symbolic</property>
-                                <property name="visible">yes</property>
-                              </object>
-                            </child>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkButton" id="reload">
-                        <property name="focus-on-click">no</property>
-                        <property name="action-name">win.tab-reload</property>
-                        <property name="visible">yes</property>
-                        <child>
-                          <object class="GtkImage">
-                            <property name="icon-name">view-refresh-symbolic</property>
-                            <property name="visible">yes</property>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkButton" id="stop_loading">
-                        <property name="focus-on-click">no</property>
-                        <property name="action-name">win.tab-stop-loading</property>
-                        <property name="visible">yes</property>
-                        <child>
-                          <object class="GtkImage">
-                            <property name="icon-name">process-stop-symbolic</property>
-                            <property name="visible">yes</property>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
-                    <child type="center">
-                      <object class="MidoriUrlbar" id="urlbar">
-                        <!-- expand has no effect, int.MAX doesn't work -->
-                        <property name="max-width-chars">300</property>
-                        <property name="margin-left">16</property>
-                        <property name="margin-right">16</property>
-                        <property name="visible">yes</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkMenuButton" id="menubutton">
-                        <property name="valign">center</property>
-                        <property name="direction">none</property>
-                        <property name="visible">yes</property>
-                      </object>
-                      <packing>
-                        <property name="pack-type">end</property>
-                      </packing>
-                    </child>
                   </object>
                 </child>
                 <child>
@@ -245,6 +182,17 @@
                     <property name="hexpand">yes</property>
                     <property name="vexpand">yes</property>
                     <property name="visible">yes</property>
+                    <!-- Invisible bar at the top to detect motion to reveal the navigationbar -->
+                    <child type="overlay">
+                      <object class="GtkEventBox">
+                        <property name="halign">start</property>
+                        <property name="valign">start</property>
+                        <property name="hexpand">yes</property>
+                        <property name="vexpand">no</property>
+                        <property name="halign">fill</property>
+                        <property name="visible">yes</property>
+                      </object>
+                    </child>
                     <child>
                       <object class="GtkStack" id="tabs">
                         <property name="transition-type">over-left-right</property>

--- a/ui/navigationbar.ui
+++ b/ui/navigationbar.ui
@@ -1,0 +1,100 @@
+<interface>
+  <template class="MidoriNavigationbar" parent="GtkActionBar">
+   <child>
+    <object class="GtkBox">
+      <property name="orientation">horizontal</property>
+      <property name="visible">yes</property>
+      <style>
+        <class name="linked"/>
+      </style>
+      <child>
+        <object class="GtkButton" id="go_back">
+          <property name="focus-on-click">no</property>
+          <property name="action-name">win.go-back</property>
+          <property name="visible">yes</property>
+          <child>
+            <object class="GtkImage">
+              <property name="icon-name">go-previous-symbolic</property>
+              <property name="visible">yes</property>
+            </object>
+          </child>
+        </object>
+      </child>
+        <child>
+          <object class="GtkButton" id="go_forward">
+            <property name="focus-on-click">no</property>
+            <property name="action-name">win.go-forward</property>
+            <property name="visible">yes</property>
+            <child>
+              <object class="GtkImage">
+                <property name="icon-name">go-next-symbolic</property>
+                <property name="visible">yes</property>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="GtkButton" id="reload">
+        <property name="focus-on-click">no</property>
+        <property name="action-name">win.tab-reload</property>
+        <property name="visible">yes</property>
+        <child>
+          <object class="GtkImage">
+            <property name="icon-name">view-refresh-symbolic</property>
+            <property name="visible">yes</property>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="GtkButton" id="stop_loading">
+        <property name="focus-on-click">no</property>
+        <property name="action-name">win.tab-stop-loading</property>
+        <property name="visible">yes</property>
+        <child>
+          <object class="GtkImage">
+            <property name="icon-name">process-stop-symbolic</property>
+            <property name="visible">yes</property>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child type="center">
+      <object class="MidoriUrlbar" id="urlbar">
+        <!-- expand has no effect, int.MAX doesn't work -->
+        <property name="max-width-chars">300</property>
+        <property name="margin-left">16</property>
+        <property name="margin-right">16</property>
+        <property name="visible">yes</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkButton" id="restore">
+        <property name="focus-on-click">no</property>
+        <property name="valign">center</property>
+        <property name="action-name">win.fullscreen</property>
+        <child>
+          <object class="GtkImage">
+            <property name="icon-name">view-restore-symbolic</property>
+            <property name="visible">yes</property>
+          </object>
+        </child>
+      </object>
+      <packing>
+        <property name="pack-type">end</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkMenuButton" id="menubutton">
+        <property name="valign">center</property>
+        <property name="direction">none</property>
+        <property name="visible">yes</property>
+      </object>
+      <packing>
+        <property name="pack-type">end</property>
+      </packing>
+    </child>
+  </template>
+</interface>


### PR DESCRIPTION
![screenshot from 2018-08-30 18-03-16](https://user-images.githubusercontent.com/1204189/44864348-b9090400-ac7f-11e8-993d-f9b9c9c8c67c.png)

Fullscreen, entered via the fullscreen button (pictured above) or F11, hides the titlebar/tabbar, panel and navigationbar (as well as the page menu). The navigationbar will reveal itself when hovering the top of the screen or ^L until it loses focus.

I'm using the opportunity to move the navigationbar into its own class/ UI file.

Fixes: #30 