### PR TITLE
More fine-grained Activatable interfaces

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,7 @@ set(DESKTOP_ICON "${CMAKE_PROJECT_NAME}" CACHE STRING "The Icon value to be used
 
 add_subdirectory (core)
 add_subdirectory (web)
+add_subdirectory (extensions)
 enable_testing()
 add_subdirectory (tests)
 add_subdirectory (po)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,7 +1,8 @@
 # Copyright (C) 2013-2018 Christian Dywan <christian@twotoasts.de>
 
-set(LIBCORE_VERSION ${CORE_VERSION})
+set(LIBCORE_VERSION 0.6)
 set(LIBCORE_SOVERSION 0)
+set(LIBCORE_GIR Midori-${LIBCORE_VERSION})
 
 file(GLOB LIBCORE_SOURCE *.vala)
 list(REMOVE_ITEM LIBCORE_SOURCE "main.vala")
@@ -21,6 +22,8 @@ CUSTOM_VAPIS
     ${EXTRA_VAPIS}
 GENERATE_VAPI
     "${LIBCORE}"
+GENERATE_GIR
+    ${LIBCORE_GIR}
 GENERATE_HEADER
     "${LIBCORE}"
 )
@@ -33,10 +36,6 @@ OPTIONS
     ${VALAFLAGS}
 CUSTOM_VAPIS
     ${EXTRA_VAPIS}
-GENERATE_VAPI
-    "${CMAKE_PROJECT_NAME}"
-GENERATE_HEADER
-    "${CMAKE_PROJECT_NAME}"
 )
 
 add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/resources.c
@@ -59,6 +58,17 @@ set_target_properties("${LIBCORE}" PROPERTIES
                       SOVERSION ${LIBCORE_SOVERSION}
                       VERSION ${LIBCORE_VERSION}
                       )
+
+find_program (GIR_COMPILER_BIN g-ir-compiler)
+add_custom_target("g-ir-compiler_${LIBCORE}" ALL
+                  ${GIR_COMPILER_BIN} ${CMAKE_CURRENT_BINARY_DIR}/${LIBCORE_GIR}.gir
+                  --output ${CMAKE_CURRENT_BINARY_DIR}/${LIBCORE_GIR}.typelib
+                  WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+                  DEPENDS ${LIBCORE_GIR}.gir)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${LIBCORE_GIR}.gir"
+        DESTINATION "${CMAKE_INSTALL_DATADIR}/gir-1.0/")
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${LIBCORE_GIR}.typelib"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/girepository-1.0/")
 
 include_directories(
                     ${CMAKE_SOURCE_DIR}

--- a/core/about.vala
+++ b/core/about.vala
@@ -11,7 +11,7 @@
 
 namespace Midori {
     [GtkTemplate (ui = "/ui/about.ui")]
-    public class About : Gtk.AboutDialog {
+    class About : Gtk.AboutDialog {
         public About (Gtk.Window parent) {
            Object (transient_for: parent,
                    website: Config.PROJECT_WEBSITE,

--- a/core/app.vala
+++ b/core/app.vala
@@ -10,6 +10,11 @@
 */
 
 namespace Midori {
+    public interface AppActivatable : Peas.ExtensionBase {
+        public abstract App app { owned get; set; }
+        public abstract void activate ();
+    }
+
     public class App : Gtk.Application {
         public File? exec_path { get; protected set; default = null; }
 
@@ -119,6 +124,10 @@ namespace Midori {
             if (!Gtk.Settings.get_default ().gtk_shell_shows_app_menu){
                 app_menu = null;
             }
+
+            var extensions = Plugins.get_default ().plug<AppActivatable> ("app", this);
+            extensions.extension_added.connect ((info, extension) => ((AppActivatable)extension).activate ());
+            extensions.foreach ((extensions, info, extension) => { extensions.extension_added (info, extension); });
         }
 
         async void internal_scheme (WebKit.URISchemeRequest request) {

--- a/core/browser.vala
+++ b/core/browser.vala
@@ -10,6 +10,11 @@
 */
 
 namespace Midori {
+    public interface BrowserActivatable : Object {
+        public abstract Browser browser { owned get; set; }
+        public abstract void activate ();
+    }
+
     [GtkTemplate (ui = "/ui/browser.ui")]
     public class Browser : Gtk.ApplicationWindow {
         public WebKit.WebContext web_context { get; construct set; }
@@ -224,7 +229,10 @@ namespace Midori {
 
             // Reveal panel toggle after panels are added
             panel.add.connect ((widget) => { panel_toggle.show (); });
-            Plugins.get_default ().plug (panel);
+
+            var extensions = Plugins.get_default ().plug<BrowserActivatable> ("browser", this);
+            extensions.extension_added.connect ((info, extension) => ((BrowserActivatable)extension).activate ());
+            extensions.foreach ((extensions, info, extension) => { extensions.extension_added (info, extension); });
         }
 
         void update_decoration_layout () {

--- a/core/clear-private-data.vala
+++ b/core/clear-private-data.vala
@@ -11,7 +11,7 @@
 
 namespace Midori {
     [GtkTemplate (ui = "/ui/clear-private-data.ui")]
-    public class ClearPrivateData : Gtk.Dialog {
+    class ClearPrivateData : Gtk.Dialog {
         [GtkChild]
         Gtk.ComboBoxText timerange;
         [GtkChild]

--- a/extensions/CMakeLists.txt
+++ b/extensions/CMakeLists.txt
@@ -1,0 +1,52 @@
+# Copyright (C) 2013-2018 Christian Dywan <christian@twotoasts.de>
+
+set(EXTENSIONDIR "${CMAKE_INSTALL_FULL_LIBDIR}/${CMAKE_PROJECT_NAME}")
+include_directories(
+                    "${CMAKE_SOURCE_DIR}"
+                    "${CMAKE_SOURCE_DIR}/core"
+                    ${DEPS_INCLUDE_DIRS}
+                    ${DEPS_GTK_INCLUDE_DIRS}
+                    ${CMAKE_BINARY_DIR}
+                    "${CMAKE_BINARY_DIR}/core"
+                    )
+file(GLOB EXTENSIONS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.c *.vala)
+foreach(UNIT_SRC ${EXTENSIONS})
+    if (${UNIT_SRC} MATCHES "(.vala)$")
+        string(REPLACE ".vala" "" UNIT ${UNIT_SRC})
+        include(ValaPrecompile)
+        vala_precompile(UNIT_SRC_C ${UNIT}
+            ${UNIT_SRC}
+        PACKAGES
+            ${PKGS}
+        OPTIONS
+            ${VALAFLAGS}
+        CUSTOM_VAPIS
+            ${CMAKE_BINARY_DIR}/core/${LIBCORE}.vapi
+            ${EXTRA_VAPIS}
+        )
+
+        add_library(${UNIT} MODULE ${UNIT_SRC_C})
+        set_target_properties(${UNIT} PROPERTIES
+                              COMPILE_FLAGS "${VALA_CFLAGS}"
+                              )
+    else()
+        string(REPLACE ".c" "" UNIT ${UNIT_SRC})
+        add_library(${UNIT} MODULE ${UNIT_SRC})
+        set_target_properties(${UNIT} PROPERTIES
+                              COMPILE_FLAGS ${CFLAGS}
+                              )
+    endif()
+    target_link_libraries(${UNIT}
+                          ${DEPS_LIBRARIES}
+                          ${DEPS_GTK_LIBRARIES}
+                          ${LIBCORE}
+                          )
+    install(TARGETS ${UNIT}
+            LIBRARY DESTINATION ${EXTENSIONDIR}
+            )
+    set(MANIFEST "${UNIT}.plugin")
+    configure_file(${MANIFEST}.in ${MANIFEST})
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${MANIFEST}
+            DESTINATION ${EXTENSIONDIR}
+            )
+endforeach ()

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -99,7 +99,10 @@ parts:
       - gstreamer1.0-libav
       - pulseaudio-module-x11
       - libmirclient9
+    organize:
+      lib/girepository-1.0/Midori-0.6.typelib: usr/lib/girepository-1.0/Midori-0.6.typelib
     stage:
+      - -usr/share/gir-1.0/Midori-0.6.gir
       - -usr/lib/*/libcups.so.2
       - -usr/share/doc/libcups2/changelog.Debian.gz
       - -usr/lib/*/libsoup-2.4.so.1.7.0


### PR DESCRIPTION
* `Plugins.plug` now takes a type and property, consumer connects signals.
* Generation of a GIR file.
* Preparation for built-in extensions in `extensions` folder.
* Tweaks to `Database` to avoid exposing `Sqlite` namespace in public API.

Note: Avoiding `owned get; construct;` with `Activatable` interfaces as
used in the definition of `Peas.Activatable` because it triggers a lot
of internal compiler assertions at build time.

Fixes: #35