### PR TITLE
Metadata updates for Flatpak-compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ configure_file(config.h.in config.h @ONLY)
 add_custom_target (uninstall
     COMMAND "xargs" "rm" "-v" "<" "install_manifest.txt")
 
-install(FILES COPYING README DESTINATION ${CMAKE_INSTALL_DOCDIR})
+install(FILES COPYING README.md DESTINATION ${CMAKE_INSTALL_DOCDIR})
 
 set(DESKTOP_ICON "${CMAKE_PROJECT_NAME}" CACHE STRING "The Icon value to be used in the .desktop file")
 

--- a/core/app.vala
+++ b/core/app.vala
@@ -31,7 +31,7 @@ namespace Midori {
         };
 
         public App () {
-            Object (application_id: "org.midori-browser.midori",
+            Object (application_id: "org.midori_browser.Midori",
                     flags: ApplicationFlags.HANDLES_OPEN
                          | ApplicationFlags.HANDLES_COMMAND_LINE);
 

--- a/data/midori.appdata.xml.in
+++ b/data/midori.appdata.xml.in
@@ -1,11 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2015-2018 Christian Dywan <christian@twotoasts.de> -->
 <component type="desktop">
-  <id>midori.desktop</id>
-  <metadata_license>CC0-1.0</metadata_license>
-  <project_license>LGPL-2.1</project_license>
-  <name>Midori</name>
-  <icon type="stock">midori</icon>
+  <id>org.midori_browser.Midori</id>
+  <launchable type="desktop-id">midori.desktop</launchable>
+  <metadata_license>LGPL-2.1-or-later</metadata_license>
+  <project_license>LGPL-2.1-or-later</project_license>
+  <_name>Midori Web Browser</_name>
+  <categories>
+    <category>Network</category>
+    <category>WebBrowser</category>
+  </categories>
+  <kudos>
+    <kudo>AppMenu</kudo>
+    <kudo>HiDpiIcon</kudo>
+    <kudo>ModernToolkit</kudo>
+    <kudo>Notifications</kudo>
+    <kudo>UserDocs</kudo>
+  </kudos>
   <summary>A fast and lightweight web browser</summary>
   <description>
     <p>
@@ -35,4 +46,11 @@
   <update_contact>christian@twotoasts.de</update_contact>
   <developer_name>Christian Dywan</developer_name>
   <url type="bugtracker">https://github.com/midori-browser/core/issues</url>
+  <url type="faq">https://www.midori-browser.org/faq</url>
+  <url type="donation">https://www.midori-browser.org/donate</url>
+  <translation type="gettext">midori</translation>
+  <content_rating type="oars-1.1" />
+  <releases>
+    <release version="0.5.11" date="2015-08-30"/>
+  </releases>
 </component>

--- a/gresource.xml
+++ b/gresource.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gresources>
-  <gresource prefix="/org/midori-browser/midori">
+  <gresource prefix="/org/midori_browser/Midori">
     <file>icons/16x16/apps/midori.png</file>
     <file>icons/22x22/apps/midori.png</file>
     <file>icons/scalable/apps/midori.svg</file>
     <file>icons/index.theme</file>
   </gresource>
-  <gresource prefix="/org/midori-browser/midori/gtk">
+  <gresource prefix="/org/midori_browser/Midori/gtk">
     <file compressed="true" preprocess="xml-stripblanks" alias="menus.ui">ui/menus.ui</file>
     <file compressed="true" preprocess="xml-stripblanks" alias="help-overlay.ui">ui/shortcuts.ui</file>
   </gresource>

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -9,19 +9,19 @@ summary: a lightweight, fast, and free web browser
 description: |
   Midori is a lightweight yet powerful web browser which runs just as well on little embedded computers named for delicious pastries as it does on beefy machines with a core temperature exceeding that of planet earth. And it looks good doing that, too. Oh, and of course it's free software.
 
-Privacy out of the box:
+  Privacy out of the box:
 
-    • Adblock filter list support.
-    • Private browsing.
-    • Manage cookies and scripts.
+      • Adblock filter list support.
+      • Private browsing.
+      • Manage cookies and scripts.
 
-Productivity features:
+  Productivity features:
 
-    • Open a 1000 tabs instantly.
-    • Easy web apps creation.
-    • Customizable side panels.
-    • User scripts and styles a la Greasemonkey.
-    • Web developer tools powered by WebKit.
+      • Open a 1000 tabs instantly.
+      • Easy web apps creation.
+      • Customizable side panels.
+      • User scripts and styles a la Greasemonkey.
+      • Web developer tools powered by WebKit.
 
 grade: stable
 confinement: strict
@@ -56,7 +56,7 @@ apps:
 
 slots:
   dbus:
-    name: org.midori-browser.midori
+    name: org.midori_browser.Midori
     bus: session
 
 parts:
@@ -106,6 +106,9 @@ parts:
       - -usr/lib/*/libsoup-gnome-2.4.so.1.7.0
       - -usr/lib/*/libjpeg.so.8.0.2
       - -usr/share/doc
+      - -usr/lib/*/libX11-xcb.so.1.0.0
+      - -usr/lib/*/libX11.so.6.3.0
+      - -usr/share/X11/locale
     after:
       - desktop-gtk3
       - snapcraft-preload


### PR DESCRIPTION
- Changing DBus name because - is not allowed by Flatpak.
- Updates to [AppStream](https://www.freedesktop.org/software/appstream/docs)

A [branch for FlatHub](https://github.com/kalikiana/flathub/tree/midori) is prepared.