### PR TITLE
Configure exact user agent to reduce fingerprinting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,9 @@ set(CFLAGS "${CFLAGS} -g")
 set(VALA_CFLAGS "-g -fPIC -w -Werror")
 
 set(LIBCORE "${CMAKE_PROJECT_NAME}-core")
+set(CORE_OS "(X11; Linux x86_64)")
+set(CORE_ENGINE "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.106 Safari/537.36")
+set(CORE_USER_AGENT "Mozilla/5.0 ${CORE_OS} ${CORE_ENGINE} Midori/6")
 
 configure_file(config.h.in config.h @ONLY)
 

--- a/config.h.in
+++ b/config.h.in
@@ -10,6 +10,7 @@
 */
 
 #cmakedefine CORE_VERSION "@CORE_VERSION@"
+#cmakedefine CORE_USER_AGENT "@CORE_USER_AGENT@"
 #cmakedefine PROJECT_NAME "@CMAKE_PROJECT_NAME@"
 #cmakedefine PROJECT_BUGS "@PROJECT_BUGS@"
 #cmakedefine PROJECT_WEBSITE "@PROJECT_WEBSITE@"

--- a/core/tab.vala
+++ b/core/tab.vala
@@ -56,9 +56,7 @@ namespace Midori {
             Object (related_view: related, web_context: web_context, visible: true);
 
             var settings = get_settings ();
-            settings.set_user_agent_with_application_details (
-                Config.PROJECT_NAME, Config.CORE_VERSION);
-            settings.user_agent = settings.user_agent.replace ("Version/11.0", "Chrome/55.0.2876.0");
+            settings.user_agent = Config.CORE_USER_AGENT;
             settings.enable_developer_extras = true;
 
             if (pinned) {

--- a/vapi/config.vapi
+++ b/vapi/config.vapi
@@ -1,6 +1,7 @@
 [CCode (cprefix = "", lower_case_cprefix = "", cheader_filename = "config.h")]
 namespace Config {
     public const string CORE_VERSION;
+    public const string CORE_USER_AGENT;
     public const string PROJECT_NAME;
     public const string PROJECT_BUGS;
     public const string PROJECT_WEBSITE;


### PR DESCRIPTION
To reduce user agent fingerprinting to a minimum it's probably wise to define the exact string we want regardless of the real WebKit and decoupled from release versions.