### PR TITLE
Implement private browsing intro as URI scheme

### DIFF
--- a/core/browser.vala
+++ b/core/browser.vala
@@ -253,7 +253,7 @@ namespace Midori {
 
         public Browser.incognito (App app) {
             Object (application: app,
-                    web_context: new WebKit.WebContext.ephemeral ());
+                    web_context: app.ephemeral_context ());
 
             profile.sensitive = false;
             remove_action ("clear-private-data");

--- a/core/tab.vala
+++ b/core/tab.vala
@@ -186,7 +186,7 @@ namespace Midori {
                     .replace ("{title}", title)
                     .replace ("{message}", message)
                     .replace ("{description}", description ?? "")
-                    .replace ("{tryagain}", _("Try Again"))
+                    .replace ("{tryagain}", "<span>%s</span>".printf (_("Try Again")))
                     .replace ("{uri}", display_uri);
                 load_alternate_html (html, display_uri, display_uri);
                 return true;

--- a/data/about.css
+++ b/data/about.css
@@ -51,6 +51,9 @@ button span {
     vertical-align: middle;
     padding: 2pt 1pt;
 }
+button:empty {
+    display: none;
+}
 
 .message {
     overflow: hidden;

--- a/data/error.html
+++ b/data/error.html
@@ -10,6 +10,7 @@
 -->
 <html>
   <head>
+    <meta charset="utf-8">
     <title>{title}</title>
     <link ref="shortcut icon" href="stock:///{icon}" />
     <style type="text/css">
@@ -26,9 +27,7 @@
         <p class="message">{message}</p>
         <span class="description">{description}</span>
         <div class="action">
-          <button onclick="window.location = '{uri}'">
-            <span>{tryagain}</span>
-          </button>
+          <button onclick="window.location = '{uri}'">{tryagain}</button>
         </div>
       </div>
     </div>

--- a/data/speed-dial.html
+++ b/data/speed-dial.html
@@ -10,6 +10,7 @@
 -->
 <html>
   <head>
+    <meta charset="utf-8">
     <title>{title}</title>
     <link ref="shortcut icon" href="stock:///{icon}" />
     <style type="text/css">


### PR DESCRIPTION
![screenshot from 2018-09-10 21-15-25](https://user-images.githubusercontent.com/1204189/45319206-7678de80-b53f-11e8-9982-dbd66c8d635b.png)

Note: This isn't actually surfacing `about:private` but just the functionality.

Fixes: #36