### PR TITLE
Implement web app mode

### DIFF
--- a/core/tab.vala
+++ b/core/tab.vala
@@ -203,6 +203,11 @@ namespace Midori {
         public override bool context_menu (WebKit.ContextMenu menu,
             Gdk.Event event, WebKit.HitTestResult hit) {
 
+            // No context menu for pinned tabs
+            if (pinned) {
+                return true;
+            }
+
             if (hit.context_is_editable ()) {
                 return false;
             }

--- a/core/tally.vala
+++ b/core/tally.vala
@@ -97,6 +97,11 @@ namespace Midori {
         }
 
         protected override bool button_press_event (Gdk.EventButton event) {
+            // No context menu for a single tab
+            if (!show_close) {
+                return false;
+            }
+
             switch (event.button) {
                 case Gdk.BUTTON_SECONDARY:
                     ((SimpleAction)group.lookup_action ("pin")).set_enabled (!tab.pinned);

--- a/ui/browser.ui
+++ b/ui/browser.ui
@@ -55,7 +55,7 @@
               </object>
             </child>
             <child>
-              <object class="GtkButton">
+              <object class="GtkButton" id="toggle_fullscreen">
                 <property name="focus-on-click">no</property>
                 <property name="valign">center</property>
                 <property name="action-name">win.fullscreen</property>
@@ -109,7 +109,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkButton">
+              <object class="GtkButton" id="tab_new">
                 <property name="focus-on-click">no</property>
                 <property name="valign">center</property>
                 <property name="action-name">win.tab-new</property>


### PR DESCRIPTION
The (web) app mode is a way to open a website like its own application via the `--app/ -a` switch. This change doesn't address creation of a launcher or management of data.

Fixes: #48