### PR TITLE
Size and spacing tweaks to downloads popover

### DIFF
--- a/core/download-button.vala
+++ b/core/download-button.vala
@@ -139,6 +139,8 @@ namespace Midori {
             item.bind_property ("icon", icon, "gicon");
             filename.label = item.basename;
             item.bind_property ("basename", filename, "label");
+            filename.tooltip_text = item.basename;
+            item.bind_property ("basename", filename, "tooltip-text");
             progress.fraction = item.progress;
             item.bind_property ("progress", progress, "fraction");
             progress.visible = item.loading;

--- a/ui/download-button.ui
+++ b/ui/download-button.ui
@@ -10,11 +10,14 @@
         <child>
           <object class="GtkBox">
             <property name="orientation">horizontal</property>
+            <property name="spacing">12</property>
+            <property name="margin">12</property>
             <property name="visible">yes</property>
             <child>
               <object class="GtkLabel">
                 <property name="label" translatable="yes">Downloads</property>
                 <property name="hexpand">yes</property>
+                <property name="width-chars">33</property>
                 <property name="visible">yes</property>
               </object>
             </child>
@@ -22,7 +25,7 @@
               <object class="GtkButton">
                 <property name="focus-on-click">no</property>
                 <property name="relief">half</property>
-                <property name="label" translatable="yes">_Clear</property>
+                <property name="label" translatable="yes" context="downloads">_Clear</property>
                 <property name="use-underline">yes</property>
                 <property name="visible">yes</property>
               </object>
@@ -44,9 +47,10 @@
   <template class="MidoriDownloadButton" parent="GtkButton">
     <property name="focus-on-click">no</property>
     <property name="action-name">win.show-downloads</property>
+    <property name="tooltip-text" translatable="yes">View downloaded files</property>
     <child>
       <object class="GtkImage">
-        <property name="icon-name">browser-download-symbolic</property>
+        <property name="icon-name">folder-download-symbolic</property>
         <property name="use-fallback">yes</property>
         <property name="visible">yes</property>
       </object>


### PR DESCRIPTION
![screenshot from 2018-09-13 17-47-33](https://user-images.githubusercontent.com/1204189/45499896-9695e100-b77d-11e8-80f6-cc541d385519.png)

- Minimum width for the downloads popover.
- Spacing and margin in the containing box.
- Tooltip for the potentially ellipsized filename.