### PR TITLE
Decouple database readonly behavior from App.incognito

### DIFF
--- a/core/app.vala
+++ b/core/app.vala
@@ -22,7 +22,7 @@ namespace Midori {
         [CCode (array_length = false, array_null_terminated = true)]
         static string[]? execute = null;
         static bool help_execute = false;
-        public static bool incognito = false;
+        static bool incognito = false;
         static bool version = false;
         const OptionEntry[] options = {
             { "app", 'a', 0, OptionArg.STRING, ref app, N_("Run ADDRESS as a web application"), N_("ADDRESS") },

--- a/core/completion.vala
+++ b/core/completion.vala
@@ -30,6 +30,7 @@ namespace Midori {
 
     public class Completion : Object, ListModel {
         List<ListModel> models = new List<ListModel> ();
+        public bool incognito { get; construct set; default = false; }
         public string? key { get; set; default = null; }
 
         construct {
@@ -39,7 +40,7 @@ namespace Midori {
             models.append (model);
 
             try {
-                add (HistoryDatabase.get_default ());
+                add (HistoryDatabase.get_default (incognito));
             } catch (DatabaseError error) {
                 debug ("Failed to initialize completion model: %s", error.message);
             }
@@ -49,7 +50,8 @@ namespace Midori {
             extensions.foreach ((extensions, info, extension) => { extensions.extension_added (info, extension); });
         }
 
-        public Completion () {
+        public Completion (bool incognito) {
+            Object (incognito: incognito);
         }
 
         /*

--- a/core/database.vala
+++ b/core/database.vala
@@ -204,6 +204,11 @@ namespace Midori {
         } }
 
         /*
+         * A read-only database will fail on insert, update and delete.
+         */
+        public bool readonly { get; protected set; default = false; }
+
+        /*
          * A new database successfully opened for the first time.
          * Old or additional data should be opened if this is true.
          */
@@ -254,7 +259,7 @@ namespace Midori {
             bool exists = exists (real_path);
 
             int flags = 0;
-            if (App.incognito) {
+            if (readonly) {
                 flags |= Sqlite.OPEN_READONLY;
             } else {
                 flags |= Sqlite.OPEN_CREATE;

--- a/core/history.vala
+++ b/core/history.vala
@@ -12,16 +12,19 @@
 namespace Midori {
     public class HistoryDatabase : Database {
         static HistoryDatabase? _default = null;
+        static HistoryDatabase? _default_incognito = null;
 
-        public static HistoryDatabase get_default () throws DatabaseError {
-            if (_default == null) {
-                _default = new HistoryDatabase ();
+        public static HistoryDatabase get_default (bool incognito=false) throws DatabaseError {
+            if (incognito) {
+                _default_incognito = _default_incognito ?? new HistoryDatabase (true);
+                return _default_incognito;
             }
+            _default = _default ?? new HistoryDatabase (false);
             return _default;
         }
 
-        HistoryDatabase () throws DatabaseError {
-            Object (path: "history.db");
+        HistoryDatabase (bool incognito) throws DatabaseError {
+            Object (path: "history.db", readonly: incognito);
             init ();
 
             try {

--- a/core/suggestion-row.vala
+++ b/core/suggestion-row.vala
@@ -69,7 +69,7 @@ namespace Midori {
                 });
             }
             // Delete button to remove suggestions from history
-            this.delete.visible = item.database != null;
+            this.delete.visible = item.database != null && !item.database.readonly;
             this.delete.clicked.connect (() => { item.delete.begin (); });
         }
 

--- a/core/tab.vala
+++ b/core/tab.vala
@@ -83,7 +83,7 @@ namespace Midori {
         async void load_uri_delayed (string? uri, string? title) {
             // Get title from history
             try {
-                var history = HistoryDatabase.get_default ();
+                var history = HistoryDatabase.get_default (web_context.is_ephemeral ());
                 var item = yield history.lookup (display_uri);
                 if (item != null) {
                     display_title = item.title;
@@ -125,6 +125,10 @@ namespace Midori {
                 item = new DatabaseItem (uri, null, new DateTime.now_local ().to_unix ());
                 // Don't add internal or blank pages to history
                 if (uri.has_prefix ("internal:") || uri.has_prefix ("about:")) {
+                    return;
+                }
+                // Don't add anything in private browsing mode
+                if (web_context.is_ephemeral ()) {
                     return;
                 }
                 try {
@@ -229,7 +233,7 @@ namespace Midori {
             }
             if (hit.context_is_link () && !hit.link_uri.has_prefix ("javascript:")) {
                 menu.append (new WebKit.ContextMenuItem.from_stock_action_with_label (WebKit.ContextMenuAction.OPEN_LINK_IN_NEW_WINDOW, _("Open Link in New _Tab")));
-                if (!App.incognito) {
+                if (!web_context.is_ephemeral ()) {
                     var action = new Gtk.Action ("link-window", _("Open Link in New _Window"), null, null);
                     action.activate.connect (() => {
                         var browser = new Browser ((App)Application.get_default ());

--- a/core/urlbar.vala
+++ b/core/urlbar.vala
@@ -116,7 +116,7 @@ namespace Midori {
                     case Gdk.Key.Delete:
                     case Gdk.Key.KP_Delete:
                         var suggestion_row = (SuggestionRow)selected_row;
-                        if (suggestion_row != null) {
+                        if (suggestion_row != null && !suggestion_row.item.database.readonly) {
                             listbox.move_cursor (Gtk.MovementStep.DISPLAY_LINES, -1);
                             suggestion_row.item.delete.begin ();
                         }
@@ -277,7 +277,7 @@ namespace Midori {
             if (!suggestions.visible) {
                 suggestions.set_default_widget (this);
                 suggestions.relative_to = this;
-                var completion = new Completion ();
+                var completion = new Completion (((Browser)get_toplevel ()).tab.web_context.is_ephemeral ());
                 bind_property ("key", completion, "key");
                 listbox.bind_model (completion, create_row);
             }


### PR DESCRIPTION
Databases other than History may need to be writable even
in a private browsing context, and more importantly there
can be browsers in different modes at the same time.

This also makes it possible to hide delete buttons and not rely
on errors when trying to modify the database.