### PR TITLE
Implement built-in session extension

### DIFF
--- a/core/app.vala
+++ b/core/app.vala
@@ -400,8 +400,7 @@ namespace Midori {
             }
 
             if (app != "") {
-                var browser = new Browser (this);
-                browser.is_locked = true;
+                var browser = new Browser (this, true);
                 var tab = new Tab (null, browser.web_context, app);
                 tab.pinned = true;
                 browser.add (tab);

--- a/core/app.vala
+++ b/core/app.vala
@@ -316,14 +316,21 @@ namespace Midori {
 
         void win_new_activated (Action action, Variant? parameter) {
             var browser = new Browser (this);
+            if (!browser.default_tab ()) {
+                browser.add (new Tab (null, browser.web_context));
+            }
             string? uri = parameter.get_string () != "" ? parameter.get_string () : null;
-            browser.add (new Tab (null, browser.web_context, uri));
+            if (uri != null) {
+                browser.add (new Tab (null, browser.web_context, uri));
+            }
             browser.show ();
         }
 
         void win_incognito_new_activated () {
             var browser = new Browser.incognito (this);
-            browser.add (new Tab (null, browser.web_context));
+            if (!browser.default_tab ()) {
+                browser.add (new Tab (null, browser.web_context));
+            }
             browser.show ();
         }
 

--- a/core/browser.vala
+++ b/core/browser.vala
@@ -69,7 +69,7 @@ namespace Midori {
         [GtkChild]
         Navigationbar navigationbar;
         [GtkChild]
-        Gtk.Stack tabs;
+        public Gtk.Stack tabs;
         [GtkChild]
         public Gtk.Overlay overlay;
         [GtkChild]

--- a/core/browser.vala
+++ b/core/browser.vala
@@ -24,7 +24,7 @@ namespace Midori {
         public Tab? tab { get; protected set; }
         public ListStore trash { get; protected set; }
         public bool is_fullscreen { get; protected set; default = false; }
-        public bool is_locked { get; set; default = false; }
+        public bool is_locked { get; construct set; default = false; }
 
         const ActionEntry[] actions = {
             { "tab-new", tab_new_activated },
@@ -292,8 +292,9 @@ namespace Midori {
          */
         public signal bool default_tab ();
 
-        public Browser (App app) {
+        public Browser (App app, bool is_locked=false) {
             Object (application: app,
+                    is_locked: is_locked,
                     web_context: WebKit.WebContext.get_default ());
         }
 

--- a/core/browser.vala
+++ b/core/browser.vala
@@ -535,6 +535,9 @@ namespace Midori {
                 tabs.child_set (tab, "title", tab.display_title);
             });
             tabs.add_titled (tab, tab.id, tab.display_title);
+            if (tabs.visible_child == null) {
+                tabs.visible_child = tab;
+            }
         }
 
         void clear_private_data_activated () {

--- a/core/browser.vala
+++ b/core/browser.vala
@@ -285,6 +285,13 @@ namespace Midori {
             navigationbar.pack_end (button);
         }
 
+        /*
+         * Requests a default tab to be added to an otherwise empty window.
+         *
+         * Connect, adding one or more windows, and return true to override.
+         */
+        public signal bool default_tab ();
+
         public Browser (App app) {
             Object (application: app,
                     web_context: WebKit.WebContext.get_default ());
@@ -370,14 +377,20 @@ namespace Midori {
         void homepage_activated () {
             var settings = CoreSettings.get_default ();
             string homepage = settings.homepage;
+            string uri;
             if ("://" in homepage) {
-                tab.load_uri (homepage);
+                uri = homepage;
             } else if ("." in homepage) {
                 // Prepend http:// if hompepage has no scheme
-                tab.load_uri ("http://" + homepage);
+                uri = "http://" + homepage;
             } else {
                 // Fallback to search if URI is about:search or anything else
-                tab.load_uri (settings.uri_for_search ());
+                uri = settings.uri_for_search ();
+            }
+            if (tab == null) {
+                add (new Tab (null, web_context, uri));
+            } else {
+                tab.load_uri (uri);
             }
         }
 
@@ -535,9 +548,6 @@ namespace Midori {
                 tabs.child_set (tab, "title", tab.display_title);
             });
             tabs.add_titled (tab, tab.id, tab.display_title);
-            if (tabs.visible_child == null) {
-                tabs.visible_child = tab;
-            }
         }
 
         void clear_private_data_activated () {

--- a/core/database.vala
+++ b/core/database.vala
@@ -376,7 +376,7 @@ namespace Midori {
         /*
          * Delete an item from the database.
          */
-        public async bool delete (DatabaseItem item) throws DatabaseError {
+        public async virtual bool delete (DatabaseItem item) throws DatabaseError {
             string sqlcmd = """
                 DELETE FROM %s WHERE rowid = :id
                 """.printf (table);

--- a/core/database.vala
+++ b/core/database.vala
@@ -324,7 +324,8 @@ namespace Midori {
         }
 
         public bool exec_script (string filename) throws DatabaseError {
-            string schema_path = "/data/%s/%s.sql".printf (table, filename);
+            string basename = Path.get_basename (path).split (".")[0];
+            string schema_path = "/data/%s/%s.sql".printf (basename, filename);
             try {
                 var schema = resources_lookup_data (schema_path, ResourceLookupFlags.NONE);
                 transaction (()=> { return exec ((string)schema.get_data ()); });

--- a/core/database.vala
+++ b/core/database.vala
@@ -545,9 +545,9 @@ namespace Midori {
             // Note: TimeSpan is defined in microseconds
             int64 maximum_age = new DateTime.now_local ().to_unix () - timespan / 1000000;
 
-            unowned string sqlcmd = """
-                DELETE FROM %s WHERE date <= :maximum_age;
-                """;
+            string sqlcmd = """
+                DELETE FROM %s WHERE date <= :maximum_age
+                """.printf (table);
             var statement = prepare (sqlcmd,
                 ":maximum_age", typeof (int64), maximum_age);
             return statement.exec ();

--- a/core/settings.vala
+++ b/core/settings.vala
@@ -10,6 +10,14 @@
 */
 
 namespace Midori {
+    [CCode (cprefix = "MIDORI_STARTUP_")]
+    public enum StartupType {
+        BLANK_PAGE,
+        HOMEPAGE,
+        LAST_OPEN_PAGES,
+        DELAYED_PAGES
+    }
+
     public class CoreSettings : Settings {
         static CoreSettings? _default = null;
 
@@ -33,6 +41,19 @@ namespace Midori {
         public void set_plugin_enabled (string plugin, bool enabled) {
             set_boolean ("extensions", "lib%s.so".printf (plugin), enabled);
         }
+
+        public StartupType load_on_startup { get {
+            var startup = get_string ("settings", "load-on-startup", "MIDORI_STARTUP_LAST_OPEN_PAGES");
+            if (startup.has_suffix ("BLANK_PAGE")) {
+                return StartupType.BLANK_PAGE;
+            } else if (startup.has_suffix ("HOMEPAGE")) {
+                return StartupType.HOMEPAGE;
+            } else {
+                return StartupType.LAST_OPEN_PAGES;
+            }
+        } set {
+            set_string ("settings", "load-on-startup", value.to_string (), "MIDORI_STARTUP_LAST_OPEN_PAGES");
+        } }
 
         public bool enable_spell_checking { get {
             return get_boolean ("settings", "enable-spell-checking", true);

--- a/core/settings.vala
+++ b/core/settings.vala
@@ -12,7 +12,7 @@
 namespace Midori {
     [CCode (cprefix = "MIDORI_STARTUP_")]
     public enum StartupType {
-        BLANK_PAGE,
+        SPEED_DIAL,
         HOMEPAGE,
         LAST_OPEN_PAGES,
         DELAYED_PAGES
@@ -42,17 +42,19 @@ namespace Midori {
             set_boolean ("extensions", "lib%s.so".printf (plugin), enabled);
         }
 
+        // Note: Speed Dial is saved as Blank Page for compatibility reasons
         public StartupType load_on_startup { get {
             var startup = get_string ("settings", "load-on-startup", "MIDORI_STARTUP_LAST_OPEN_PAGES");
             if (startup.has_suffix ("BLANK_PAGE")) {
-                return StartupType.BLANK_PAGE;
+                return StartupType.SPEED_DIAL;
             } else if (startup.has_suffix ("HOMEPAGE")) {
                 return StartupType.HOMEPAGE;
             } else {
                 return StartupType.LAST_OPEN_PAGES;
             }
         } set {
-            set_string ("settings", "load-on-startup", value.to_string (), "MIDORI_STARTUP_LAST_OPEN_PAGES");
+            var startup = value == StartupType.SPEED_DIAL ? "MIDORI_STARTUP_BLANK_PAGE" : value.to_string ();
+            set_string ("settings", "load-on-startup", startup, "MIDORI_STARTUP_LAST_OPEN_PAGES");
         } }
 
         public bool enable_spell_checking { get {

--- a/data/tabby/Create.sql
+++ b/data/tabby/Create.sql
@@ -1,0 +1,33 @@
+CREATE TABLE IF NOT EXISTS sessions
+(
+    id INTEGER PRIMARY KEY,
+    parent_id INTEGER DEFAULT 0,
+    crdate INTEGER DEFAULT 0,
+    tstamp INTEGER DEFAULT 0,
+    closed INTEGER DEFAULT 0,
+    title TEXT DEFAULT NULL,
+    FOREIGN KEY(parent_id) REFERENCES sessions(id)
+);
+
+CREATE TABLE IF NOT EXISTS tabs
+(
+    id INTEGER PRIMARY KEY,
+    session_id INTEGER NOT NULL,
+    uri TEXT DEFAULT NULL,
+    icon TEXT DEFAULT NULL,
+    title TEXT DEFAULT NULL,
+    crdate INTEGER DEFAULT 0,
+    tstamp INTEGER DEFAULT 0,
+    closed INTEGER DEFAULT 0,
+    FOREIGN KEY(session_id) REFERENCES sessions(id)
+);
+
+CREATE TABLE IF NOT EXISTS tab_history
+(
+    id INTEGER PRIMARY KEY,
+    tab_id INTEGER,
+    url TEXT,
+    icon TEXT,
+    title TEXT,
+    FOREIGN KEY(tab_id) REFERENCES tabs(id)
+);

--- a/data/tabby/Update1.sql
+++ b/data/tabby/Update1.sql
@@ -1,0 +1,4 @@
+ALTER TABLE tabs ADD sorting REAL DEFAULT 0;
+
+CREATE INDEX sorting on tabs (sorting ASC);
+CREATE INDEX tstamp on tabs (tstamp ASC);

--- a/extensions/session.plugin.in
+++ b/extensions/session.plugin.in
@@ -1,0 +1,5 @@
+[Plugin]
+Module=session
+IAge=3
+Builtin=true
+Name=Session

--- a/extensions/session.vala
+++ b/extensions/session.vala
@@ -1,0 +1,291 @@
+/*
+ Copyright (C) 2013-2018 Christian Dywan <christian@twotoats.de>
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+
+ See the file COPYING for the full license text.
+*/
+
+namespace Tabby {
+    class SessionDatabase : Midori.Database {
+        static SessionDatabase? _default = null;
+        // Note: Using string instead of int64 because it's a hashable type
+        HashTable<string, Midori.Browser> browsers;
+
+        public static SessionDatabase get_default () throws Midori.DatabaseError {
+            if (_default == null) {
+                _default = new SessionDatabase ();
+            }
+            return _default;
+        }
+
+        SessionDatabase () throws Midori.DatabaseError {
+            Object (path: "tabby.db", table: "tabs");
+            init ();
+            browsers = new HashTable<string, Midori.Browser> (str_hash, str_equal);
+        }
+
+        public async override List<Midori.DatabaseItem>? query (string? filter=null, int64 max_items=int64.MAX, Cancellable? cancellable=null) throws Midori.DatabaseError {
+            string where = filter != null ? "AND (uri LIKE :filter OR title LIKE :filter)" : "";
+            string sqlcmd = """
+                SELECT id, uri, title, tstamp, session_id, closed FROM %s
+                WHERE closed = 0 %s
+                OR (session_id = (SELECT DISTINCT session_id from tabs ORDER BY tstamp DESC LIMIT 1))
+                ORDER BY closed, tstamp DESC LIMIT :limit
+                """.printf (table, where);
+            var statement = prepare (sqlcmd,
+                ":limit", typeof (int64), max_items);
+            if (filter != null) {
+                string real_filter = "%" + filter.replace (" ", "%") + "%";
+                statement.bind (":filter", typeof (string), real_filter);
+            }
+
+            bool? fallback_to_closed = null;
+            var items = new List<Midori.DatabaseItem> ();
+            while (statement.step ()) {
+                // Get only non-closed or only closed tabs
+                bool closed = statement.get_int64 ("closed") == 1;
+                if (fallback_to_closed == null) {
+                    fallback_to_closed = closed;
+                } else if (fallback_to_closed != closed) {
+                    continue;
+                }
+
+                string uri = statement.get_string ("uri");
+                string title = statement.get_string ("title");
+                int64 date = statement.get_int64 ("tstamp");
+                var item = new Midori.DatabaseItem (uri, title, date);
+                item.database = this;
+                item.id = statement.get_int64 ("id");
+                item.set_data<int64> ("session_id", statement.get_int64 ("session_id"));
+                items.append (item);
+
+                uint src = Idle.add (query.callback);
+                yield;
+                Source.remove (src);
+
+                if (cancellable != null && cancellable.is_cancelled ())
+                    return null;
+            }
+
+            if (cancellable != null && cancellable.is_cancelled ())
+                return null;
+            return items;
+        }
+
+        public async override bool insert (Midori.DatabaseItem item) throws Midori.DatabaseError {
+            item.database = this;
+
+            string sqlcmd = """
+                INSERT INTO %s (crdate, tstamp, session_id, uri, title)
+                VALUES (:crdate, :tstamp, :session_id, :uri, :title)
+                """.printf (table);
+
+            var statement = prepare (sqlcmd,
+                ":crdate", typeof (int64), item.date,
+                ":tstamp", typeof (int64), item.date,
+                ":session_id", typeof (int64), item.get_data<int64> ("session_id"),
+                ":uri", typeof (string), item.uri,
+                ":title", typeof (string), item.title);
+            if (statement.exec ()) {
+                item.id = statement.row_id ();
+                return true;
+            }
+            return false;
+        }
+
+        public async override bool update (Midori.DatabaseItem item) throws Midori.DatabaseError {
+            string sqlcmd = """
+                UPDATE %s SET uri = :uri, title = :title, tstamp = :tstamp, closed = 0 WHERE id = :id
+                """.printf (table);
+            try {
+                var statement = prepare (sqlcmd,
+                    ":id", typeof (int64), item.id,
+                    ":uri", typeof (string), item.uri,
+                    ":title", typeof (string), item.title,
+                    ":tstamp", typeof (int64), new DateTime.now_local ().to_unix ());
+                if (statement.exec ()) {
+                    return true;
+                }
+            } catch (Midori.DatabaseError error) {
+                critical ("Failed to update %s: %s", table, error.message);
+            }
+            return false;
+        }
+
+        public async override bool delete (Midori.DatabaseItem item) throws Midori.DatabaseError {
+            // Delete in the context of a session means close, so we can re-open as well
+            string sqlcmd = """
+                UPDATE %s SET closed = 1, tstamp = :tstamp WHERE id = :id
+                """.printf (table);
+            var statement = prepare (sqlcmd,
+                ":id", typeof (int64), item.id,
+                ":tstamp", typeof (int64), new DateTime.now_local ().to_unix ());
+            if (statement.exec ()) {
+                return true;
+            }
+            return false;
+        }
+
+        int64 insert_session () {
+            string sqlcmd = """
+                INSERT INTO sessions (tstamp) VALUES (:tstamp)
+                """;
+            try {
+                var statement = prepare (sqlcmd,
+                    ":tstamp", typeof (int64), new DateTime.now_local ().to_unix ());
+                statement.exec ();
+                debug ("Added session: %s", statement.row_id ().to_string ());
+                return statement.row_id ();
+            } catch (Midori.DatabaseError error) {
+                critical ("Failed to add session: %s", error.message);
+            }
+            return -1;
+         }
+
+        void update_session (int64 id, bool closed) {
+            string sqlcmd = """
+                UPDATE sessions SET closed=:closed, tstamp=:tstamp WHERE id = :id
+                """;
+            try {
+                var statement = prepare (sqlcmd,
+                    ":id", typeof (int64), id,
+                    ":tstamp", typeof (int64), new DateTime.now_local ().to_unix (),
+                    ":closed", typeof (int64), closed ? 1 : 0);
+                statement.exec ();
+            } catch (Midori.DatabaseError error) {
+                critical ("Failed to update session: %s", error.message);
+            }
+        }
+
+        public async void restore_session (Midori.App app) throws Midori.DatabaseError {
+            // Keep track of new windows
+            app.window_added.connect ((window) => {
+                Timeout.add (1000, () => {
+                    var browser = window as Midori.Browser;
+                    // Don't track locked (app) or private windows
+                    if (browser.is_locked || browser.web_context.is_ephemeral ()) {
+                        return Source.REMOVE;
+                    }
+                    // Skip windows already in the session
+                    if (browser.get_data<bool> ("tabby_connected")) {
+                        return Source.REMOVE;
+                    }
+                    connect_browser (browser, insert_session ());
+                    return Source.REMOVE;
+                });
+            });
+
+            // Create first browser right away to claim the active_window
+            // which is also going to receive whatever is opened via Application.open()
+            var default_browser = new Midori.Browser (app);
+            default_browser.show ();
+
+            // Restore existing session(s) that weren't closed, or the last closed one
+            foreach (var item in yield query ()) {
+                Midori.Browser browser;
+                int64 id = item.get_data<int64> ("session_id");
+                if (default_browser != null) {
+                    browser = default_browser;
+                    default_browser = null;
+                    connect_browser (browser, id);
+                    foreach (var widget in browser.tabs.get_children ()) {
+                        yield tab_added (widget as Midori.Tab);
+                    }
+                } else {
+                    browser = browser_for_session (app, id);
+                }
+                var tab = new Midori.Tab (browser.tab, browser.web_context,
+                                          item.uri, item.title);
+                connect_tab (tab, item);
+                browser.add (tab);
+            }
+        }
+
+        Midori.Browser browser_for_session (Midori.App app, int64 id) {
+            var browser = browsers.lookup (id.to_string ());
+            if (browser == null) {
+                debug ("Restoring session %s", id.to_string ());
+                browser = new Midori.Browser (app);
+                browser.show ();
+                connect_browser (browser, id);
+            }
+            return browser;
+        }
+
+        void connect_browser (Midori.Browser browser, int64 id) {
+            browsers.insert (id.to_string (), browser);
+            browser.set_data<bool> ("tabby_connected", true);
+            foreach (var widget in browser.tabs.get_children ()) {
+                tab_added.begin (widget as Midori.Tab);
+            }
+            browser.tabs.add.connect ((widget) => { tab_added.begin (widget as Midori.Tab); });
+            browser.tabs.remove.connect ((widget) => { tab_removed (widget as Midori.Tab); });
+            browser.delete_event.connect ((event) => {
+                debug ("Closing session %s", id.to_string ());
+                foreach (var widget in browser.tabs.get_children ()) {
+                    tab_removed (widget as Midori.Tab);
+                }
+                update_session (id, true);
+                return false;
+            });
+        }
+
+        void connect_tab (Midori.Tab tab, Midori.DatabaseItem item) {
+            debug ("Connecting %s to session %s", item.uri, item.get_data<int64> ("session_id").to_string ());
+            tab.set_data<Midori.DatabaseItem?> ("tabby-item", item);
+            tab.notify["uri"].connect ((pspec) => { item.uri = tab.uri; update.begin (item); });
+            tab.notify["title"].connect ((pspec) => { item.title = tab.title; });
+        }
+
+        bool tab_is_connected (Midori.Tab tab) {
+            return tab.get_data<Midori.DatabaseItem?> ("tabby-item") != null;
+        }
+
+        async void tab_added (Midori.Tab tab) {
+            if (tab_is_connected (tab)) {
+                return;
+            }
+            var item = new Midori.DatabaseItem (tab.display_uri, tab.display_title,
+                                                new DateTime.now_local ().to_unix ());
+            try {
+                yield insert (item);
+                connect_tab (tab, item);
+            } catch (Midori.DatabaseError error) {
+                critical ("Failed add tab to session database: %s", error.message);
+            }
+        }
+
+        void tab_removed (Midori.Tab tab) {
+            var item = tab.get_data<Midori.DatabaseItem?> ("tabby-item");
+            debug ("Trashing tab %s:%s", item.get_data<int64> ("session_id").to_string (), tab.display_uri);
+            item.delete.begin ();
+        }
+    }
+
+    public class Session : Peas.ExtensionBase, Midori.AppActivatable {
+        public Midori.App app { owned get; set; }
+
+        public void activate () {
+            activate_async.begin ();
+        }
+
+        async void activate_async () {
+            try {
+                yield SessionDatabase.get_default ().restore_session (app);
+            } catch (Midori.DatabaseError error) {
+                critical ("Failed to restore session: %s", error.message);
+            }
+        }
+    }
+}
+
+[ModuleInit]
+public void peas_register_types(TypeModule module) {
+    ((Peas.ObjectModule)module).register_extension_type (
+        typeof (Midori.AppActivatable), typeof (Tabby.Session));
+
+}

--- a/extensions/session.vala
+++ b/extensions/session.vala
@@ -203,6 +203,11 @@ namespace Tabby {
                 connect_tab (tab, item);
                 browser.add (tab);
             }
+
+            // Nothing was restored, so we're left with one empty browser
+            if (default_browser != null) {
+                default_browser.add (new Midori.Tab (null, default_browser.web_context));
+            }
         }
 
         Midori.Browser browser_for_session (Midori.App app, int64 id) {

--- a/gresource.xml
+++ b/gresource.xml
@@ -19,6 +19,8 @@
     <file compressed="true">data/bookmarks/Create.sql</file>
     <file compressed="true">data/history/Create.sql</file>
     <file compressed="true">data/history/Day.sql</file>
+    <file compressed="true">data/tabby/Create.sql</file>
+    <file compressed="true">data/tabby/Update1.sql</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/about.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/bookmarks-button.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/browser.ui</file>

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -41,6 +41,8 @@ extensions/statusbar-features.in
 extensions/statusbar-features.vala
 extensions/colorful-tabs.plugin.in
 extensions/colorful-tabs.vala
+extensions/session.plugin.in
+extensions/session.vala
 ui/bookmarks-button.ui
 ui/browser.ui
 ui/clear-private-data.ui


### PR DESCRIPTION
- The database schema is compatible with the original tabby.
- Every browser is a "session".
- Each tab is part of a session and can be closed.
- The last closed session (window) is restored as a fallback.
- `Midori.Database.insert/ update/ delete` become virtual.
- `Midori.Browser.tabs` is made public.
- `Midori.Browser.add` ensures there's at least one visible tab.
- The new `ClearPrivateDataActivatable` allows adding buttons and clearing data used by an extension, in this case previously open tabs.

Follow-ups:
- See #70 for closed storing tabs in the session 
- See #71 for historing tab history
- See #142 for re-rodering of tabs

Closes: #41