### PR TITLE
Fix intltool, gresource and gir targets

### DIFF
--- a/cmake/FindIntltool.cmake
+++ b/cmake/FindIntltool.cmake
@@ -2,7 +2,7 @@
 #
 # Jim Nelson <jim@yorba.org>
 # Copyright 2012-2013 Yorba Foundation
-# Copyright (C) 2013 Christian Dywan
+# Copyright (C) 2013-2018 Christian Dywan
 
 find_program (INTLTOOL_MERGE_EXECUTABLE intltool-merge)
 find_program (INTLTOOL_UPDATE_EXECUTABLE intltool-update)
@@ -10,17 +10,19 @@ find_program (INTLTOOL_UPDATE_EXECUTABLE intltool-update)
 if (INTLTOOL_MERGE_EXECUTABLE)
     set (INTLTOOL_MERGE_FOUND TRUE)
     macro (INTLTOOL_MERGE_DESKTOP desktop_id po_dir)
-        add_custom_target ("${desktop_id}.desktop" ALL
-            ${INTLTOOL_MERGE_EXECUTABLE} --desktop-style ${CMAKE_SOURCE_DIR}/${po_dir}
-                ${CMAKE_CURRENT_SOURCE_DIR}/${desktop_id}.desktop.in ${desktop_id}.desktop
+        add_custom_command (OUTPUT ${desktop_id}.desktop
+            COMMAND ${INTLTOOL_MERGE_EXECUTABLE} --desktop-style ${CMAKE_SOURCE_DIR}/${po_dir}
+                ${desktop_id}.desktop.in ${desktop_id}.desktop
+            DEPENDS ${desktop_id}.desktop.in
         )
         install (FILES "${CMAKE_CURRENT_BINARY_DIR}/${desktop_id}.desktop"
                  DESTINATION "${CMAKE_INSTALL_PREFIX}/share/applications")
     endmacro (INTLTOOL_MERGE_DESKTOP desktop_id po_dir)
     macro (INTLTOOL_MERGE_APPDATA desktop_id po_dir)
-        add_custom_target ("${desktop_id}.appdata.xml" ALL
-            ${INTLTOOL_MERGE_EXECUTABLE} --xml-style ${CMAKE_SOURCE_DIR}/${po_dir}
-                ${CMAKE_CURRENT_SOURCE_DIR}/${desktop_id}.appdata.xml.in ${desktop_id}.appdata.xml
+        add_custom_target (OUTPUT "${desktop_id}.appdata.xml"
+            COMMAND ${INTLTOOL_MERGE_EXECUTABLE} --xml-style ${CMAKE_SOURCE_DIR}/${po_dir}
+                ${desktop_id}.appdata.xml.in ${desktop_id}.appdata.xml
+            DEPENDS ${desktop_id}.appdata.xml.in
         )
         install (FILES "${CMAKE_CURRENT_BINARY_DIR}/${desktop_id}.appdata.xml"
                  DESTINATION "${CMAKE_INSTALL_PREFIX}/share/appdata")

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -38,13 +38,16 @@ CUSTOM_VAPIS
     ${EXTRA_VAPIS}
 )
 
+file(GLOB UI_FILES ${CMAKE_SOURCE_DIR}/ui/*.ui)
 add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/resources.c
-                   COMMENT "Built resource"
                    COMMAND glib-compile-resources
                    --sourcedir ${CMAKE_SOURCE_DIR}
                    --generate-source
                    --target ${CMAKE_CURRENT_BINARY_DIR}/resources.c
-                   ${CMAKE_SOURCE_DIR}/gresource.xml)
+                   ${CMAKE_SOURCE_DIR}/gresource.xml
+                   DEPENDS ${CMAKE_SOURCE_DIR}/gresource.xml
+                   DEPENDS ${UI_FILES}
+)
 
 add_library("${LIBCORE}" SHARED ${LIBCORE_SOURCE_C} ${CMAKE_CURRENT_BINARY_DIR}/resources.c)
 target_link_libraries("${LIBCORE}"
@@ -60,11 +63,11 @@ set_target_properties("${LIBCORE}" PROPERTIES
                       )
 
 find_program (GIR_COMPILER_BIN g-ir-compiler)
-add_custom_target("g-ir-compiler_${LIBCORE}" ALL
-                  ${GIR_COMPILER_BIN} ${CMAKE_CURRENT_BINARY_DIR}/${LIBCORE_GIR}.gir
-                  --output ${CMAKE_CURRENT_BINARY_DIR}/${LIBCORE_GIR}.typelib
-                  WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
-                  DEPENDS ${LIBCORE_GIR}.gir)
+add_custom_command(OUTPUT "g-ir-compiler_${LIBCORE}"
+                   COMMAND ${GIR_COMPILER_BIN} ${CMAKE_CURRENT_BINARY_DIR}/${LIBCORE_GIR}.gir
+                   --output ${CMAKE_CURRENT_BINARY_DIR}/${LIBCORE_GIR}.typelib
+                   WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+                   DEPENDS ${LIBCORE_GIR}.gir)
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${LIBCORE_GIR}.gir"
         DESTINATION "${CMAKE_INSTALL_DATADIR}/gir-1.0/")
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${LIBCORE_GIR}.typelib"


### PR DESCRIPTION
- Even when running `ninja` repeatedly without having made any changes to the source, some files always seem to be rebuilding.
- Changes in ui files aren't reliably being picked up.

Both of these problems can be explained by erroneous usage of CMake targets:

- add_custom_command should be used to generate files rather than add_custom_target which builds unconditionally.
- DEPENDS needs to specify all source files.
- For gresource.xml all ui files are dependencies.