### PR TITLE
Don't add internal or blank pages to trash

### DIFF
--- a/core/browser.vala
+++ b/core/browser.vala
@@ -460,6 +460,10 @@ namespace Midori {
                 return false;
             });
             tab.close.connect (() => {
+                // Don't add internal or blank pages to trash
+                if (tab.item.uri.has_prefix ("internal:") || tab.item.uri.has_prefix ("about:")) {
+                    return;
+                }
                 trash.append (tab.item);
             });
             // Support Gtk.StackSwitcher


### PR DESCRIPTION
Special pages shouldn't be stored in the trash. Might be nicer to find a more generic solution for this behavior long-term since eg. the same applies to history.