### PR TITLE
Implement built-in bookmark extension

### DIFF
--- a/core/database.vala
+++ b/core/database.vala
@@ -489,7 +489,7 @@ namespace Midori {
         /*
          * Update an existing item.
          */
-        public async bool update (DatabaseItem item) throws DatabaseError {
+        public virtual async bool update (DatabaseItem item) throws DatabaseError {
             string sqlcmd = """
                 UPDATE %s SET uri=:uri, title=:title, date=:date WHERE rowid = :id
                 """.printf (table);
@@ -515,7 +515,7 @@ namespace Midori {
         /*
          * Insert an item into the database.
          */
-        public async bool insert (DatabaseItem item) throws DatabaseError {
+        public virtual async bool insert (DatabaseItem item) throws DatabaseError {
             item.database = this;
 
             string sqlcmd = """

--- a/data/bookmarks/Create.sql
+++ b/data/bookmarks/Create.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS bookmarks
+(
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    parentid INTEGER DEFAULT NULL,
+    title TEXT,
+    uri TEXT,
+    desc TEXT,
+    app INTEGER,
+    toolbar INTEGER,
+    pos_panel INTEGER,
+    pos_bar INTEGER,
+    created DATE DEFAULT CURRENT_TIMESTAMP,
+    last_visit DATE,
+    visit_count INTEGER DEFAULT 0,
+    nick TEXT,
+
+    FOREIGN KEY(parentid) REFERENCES bookmarks(id) ON DELETE CASCADE
+);

--- a/extensions/CMakeLists.txt
+++ b/extensions/CMakeLists.txt
@@ -20,6 +20,7 @@ foreach(UNIT_SRC ${EXTENSIONS})
             ${PKGS}
         OPTIONS
             ${VALAFLAGS}
+            --gresources="${CMAKE_SOURCE_DIR}/gresource.xml"
         CUSTOM_VAPIS
             ${CMAKE_BINARY_DIR}/core/${LIBCORE}.vapi
             ${EXTRA_VAPIS}

--- a/extensions/bookmarks.plugin.in
+++ b/extensions/bookmarks.plugin.in
@@ -1,0 +1,6 @@
+[Plugin]
+Module=bookmarks
+IAge=3
+Builtin=true
+Name=Bookmarks
+Description=Show the saved bookmarks

--- a/extensions/bookmarks.vala
+++ b/extensions/bookmarks.vala
@@ -123,6 +123,8 @@ namespace Bookmarks {
         Gtk.Popover popover;
         [GtkChild]
         Gtk.Entry entry_title;
+        [GtkChild]
+        Gtk.Button button_remove;
 
         Midori.Browser browser;
 
@@ -133,6 +135,12 @@ namespace Bookmarks {
                 if (item != null) {
                     item.title = entry_title.text;
                 }
+            });
+            button_remove.clicked.connect (() => {
+                popover.hide ();
+                var item = browser.tab.get_data<Midori.DatabaseItem?> ("bookmarks-item");
+                item.delete.begin ();
+                browser.tab.set_data<Midori.DatabaseItem?> ("bookmarks-item", null);
             });
         }
 

--- a/extensions/bookmarks.vala
+++ b/extensions/bookmarks.vala
@@ -1,0 +1,212 @@
+/*
+ Copyright (C) 2013-2018 Christian Dywan <christian@twotoats.de>
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+
+ See the file COPYING for the full license text.
+*/
+
+namespace Bookmarks {
+    class BookmarksDatabase : Midori.Database {
+        static BookmarksDatabase? _default = null;
+        public static BookmarksDatabase get_default () throws Midori.DatabaseError {
+            if (_default == null) {
+                _default = new BookmarksDatabase ();
+            }
+            return _default;
+        }
+
+        BookmarksDatabase () throws Midori.DatabaseError {
+            Object (path: "bookmarks.db");
+            init ();
+        }
+
+        public async override Midori.DatabaseItem? lookup (string uri) throws Midori.DatabaseError {
+            string sqlcmd = """
+                SELECT id, title FROM %s WHERE uri = :uri LIMIT 1
+                """.printf (table);
+            var statement = prepare (sqlcmd,
+                ":uri", typeof (string), uri);
+            if (statement.step ()) {
+                string title = statement.get_string ("title");
+                var item = new Midori.DatabaseItem (uri, title);
+                item.database = this;
+                item.id = statement.get_int64 ("id");
+                return item;
+            }
+            return null;
+        }
+
+        public async override List<Midori.DatabaseItem>? query (string? filter=null, int64 max_items=15, Cancellable? cancellable=null) throws Midori.DatabaseError {
+            string where = filter != null ? "WHERE uri LIKE :filter OR title LIKE :filter" : "";
+            string sqlcmd = """
+                SELECT id, uri, title, visit_count AS ct FROM %s
+                %s
+                GROUP BY uri
+                ORDER BY ct DESC LIMIT :limit
+                """.printf (table, where);
+
+            try {
+                var statement = prepare (sqlcmd,
+                    ":limit", typeof (int64), max_items);
+                if (filter != null) {
+                    string real_filter = "%" + filter.replace (" ", "%") + "%";
+                    statement.bind (":filter", typeof (string), real_filter);
+                }
+
+                var items = new List<Midori.DatabaseItem> ();
+                while (statement.step ()) {
+                    string uri = statement.get_string ("uri");
+                    string title = statement.get_string ("title");
+                    var item = new Midori.DatabaseItem (uri, title);
+                    item.database = this;
+                    item.id = statement.get_int64 ("id");
+                    items.append (item);
+
+                    uint src = Idle.add (query.callback);
+                    yield;
+                    Source.remove (src);
+
+                    if (cancellable != null && cancellable.is_cancelled ())
+                        return null;
+                }
+                if (cancellable != null && cancellable.is_cancelled ())
+                    return null;
+                return items;
+            } catch (Midori.DatabaseError error) {
+                critical ("Failed to query bookmarks: %s", error.message);
+            }
+            return null;
+        }
+
+        public async override bool update (Midori.DatabaseItem item) throws Midori.DatabaseError {
+            string sqlcmd = """
+                UPDATE %s SET uri = :uri, title = :title WHERE id = :id
+                """.printf (table);
+            try {
+                var statement = prepare (sqlcmd,
+                    ":id", typeof (int64), item.id,
+                    ":uri", typeof (string), item.uri,
+                    ":title", typeof (string), item.title);
+                if (statement.exec ()) {
+                    return true;
+                }
+            } catch (Error error) {
+                critical ("Failed to update %s: %s", table, error.message);
+            }
+            return false;
+        }
+
+        public async override bool insert (Midori.DatabaseItem item) throws Midori.DatabaseError {
+            item.database = this;
+
+            string sqlcmd = """
+                INSERT INTO %s (uri, title) VALUES (:uri, :title)
+                """.printf (table);
+            var statement = prepare (sqlcmd,
+                ":uri", typeof (string), item.uri,
+                ":title", typeof (string), item.title);
+            if (statement.exec ()) {
+                item.id = statement.row_id ();
+                return true;
+            }
+            return false;
+        }
+    }
+
+    [GtkTemplate (ui = "/ui/bookmarks-button.ui")]
+    public class Button : Gtk.Button {
+        [GtkChild]
+        Gtk.Popover popover;
+        [GtkChild]
+        Gtk.Entry entry_title;
+
+        Midori.Browser browser;
+
+        construct {
+            popover.relative_to = this;
+            entry_title.changed.connect (() => {
+                var item = browser.tab.get_data<Midori.DatabaseItem?> ("bookmarks-item");
+                if (item != null) {
+                    item.title = entry_title.text;
+                }
+            });
+        }
+
+        async Midori.DatabaseItem item_for_tab (Midori.Tab tab) {
+            var item = tab.get_data<Midori.DatabaseItem?> ("bookmarks-item");
+            if (item == null) {
+                try {
+                    item = yield BookmarksDatabase.get_default ().lookup (tab.display_uri);
+                } catch (Midori.DatabaseError error) {
+                    critical ("Failed to lookup %s in bookmarks database: %s", tab.display_uri, error.message);
+                }
+                if (item == null) {
+                    item = new Midori.DatabaseItem (tab.display_uri, tab.display_title);
+                    try {
+                        yield BookmarksDatabase.get_default ().insert (item);
+                    } catch (Midori.DatabaseError error) {
+                        critical ("Failed to add %s to bookmarks database: %s", item.uri, error.message);
+                    }
+                }
+                entry_title.text = item.title;
+                tab.set_data<Midori.DatabaseItem?> ("bookmarks-item", item);
+            }
+            return item;
+        }
+
+        public virtual signal void add_bookmark () {
+            var tab = browser.tab;
+            item_for_tab.begin (tab);
+            popover.show ();
+        }
+
+        public Button (Midori.Browser browser) {
+            this.browser = browser;
+
+            var action = new SimpleAction ("bookmark-add", null);
+            action.activate.connect (bookmark_add_activated);
+            browser.notify["uri"].connect (() => {
+                action.set_enabled (browser.uri.has_prefix ("http"));
+            });
+            browser.add_action (action);
+            browser.application.set_accels_for_action ("win.bookmark-add", { "<Primary>d" });
+        }
+
+        void bookmark_add_activated () {
+            add_bookmark ();
+        }
+    }
+
+    public class Frontend : Object, Midori.BrowserActivatable {
+        public Midori.Browser browser { owned get; set; }
+
+        public void activate () {
+            browser.add_button (new Button (browser));
+        }
+    }
+
+    public class Completion : Peas.ExtensionBase, Midori.CompletionActivatable {
+        public Midori.Completion completion { owned get; set; }
+
+        public void activate () {
+            try {
+                completion.add (BookmarksDatabase.get_default ());
+            } catch (Midori.DatabaseError error) {
+                critical ("Failed to add bookmarks completion: %s", error.message);
+            }
+        }
+    }
+}
+
+[ModuleInit]
+public void peas_register_types(TypeModule module) {
+    ((Peas.ObjectModule)module).register_extension_type (
+        typeof (Midori.BrowserActivatable), typeof (Bookmarks.Frontend));
+    ((Peas.ObjectModule)module).register_extension_type (
+        typeof (Midori.CompletionActivatable), typeof (Bookmarks.Completion));
+
+}

--- a/gresource.xml
+++ b/gresource.xml
@@ -16,9 +16,11 @@
     <file compressed="true">data/speed-dial.html</file>
     <file compressed="true">data/gtk3.css</file>
     <file compressed="true">data/logo-shade.svg</file>
+    <file compressed="true">data/bookmarks/Create.sql</file>
     <file compressed="true">data/history/Create.sql</file>
     <file compressed="true">data/history/Day.sql</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/about.ui</file>
+    <file compressed="true" preprocess="xml-stripblanks">ui/bookmarks-button.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/browser.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/clear-private-data.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/download-button.ui</file>

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -22,6 +22,9 @@ core/switcher.vala
 core/tab.vala
 core/tally.vala
 core/urlbar.vala
+extensions/bookmarks.plugin.in
+extensions/bookmarks.vala
+ui/bookmarks-button.ui
 ui/browser.ui
 ui/clear-private-data.ui
 ui/download-button.ui

--- a/ui/bookmarks-button.ui
+++ b/ui/bookmarks-button.ui
@@ -41,7 +41,7 @@
           <object class="GtkActionBar">
             <property name="visible">yes</property>
             <child>
-              <object class="GtkButton" id="remove">
+              <object class="GtkButton" id="button_remove">
                 <property name="label" translatable="yes">_Remove Bookmark</property>
                 <property name="use-underline">yes</property>
                 <property name="visible">yes</property>

--- a/ui/bookmarks-button.ui
+++ b/ui/bookmarks-button.ui
@@ -1,0 +1,74 @@
+<interface>
+  <object class="GtkPopover" id="popover">
+    <property name="modal">yes</property>
+    <child>
+      <object class="GtkBox">
+        <property name="orientation">vertical</property>
+        <property name="spacing">12</property>
+        <property name="margin">12</property>
+        <property name="visible">yes</property>
+        <child>
+          <object class="GtkBox">
+            <property name="orientation">horizontal</property>
+            <property name="spacing">12</property>
+            <property name="margin">12</property>
+            <property name="visible">yes</property>
+            <child>
+              <object class="GtkImage">
+                <property name="icon-name">bookmark-new-symbolic</property>
+                <property name="use-fallback">yes</property>
+                <property name="visible">yes</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="label" translatable="yes">Edit Bookmark</property>
+                <property name="wrap">yes</property>
+                <property name="max-width-chars">33</property>
+                <property name="hexpand">yes</property>
+                <property name="visible">yes</property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkEntry" id="entry_title">
+            <property name="max-width-chars">33</property>
+            <property name="visible">yes</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkActionBar">
+            <property name="visible">yes</property>
+            <child>
+              <object class="GtkButton" id="remove">
+                <property name="label" translatable="yes">_Remove Bookmark</property>
+                <property name="use-underline">yes</property>
+                <property name="visible">yes</property>
+                <style>
+                  <class name="destructive-action"/>
+                </style>
+              </object>
+              <packing>
+                <property name="pack-type">end</property>
+              </packing>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+  </object>
+  <template class="BookmarksButton" parent="GtkButton">
+    <property name="focus-on-click">no</property>
+    <property name="action-name">win.bookmark-add</property>
+    <property name="tooltip-text" translatable="yes">Add a new bookmark</property>
+    <property name="visible">yes</property>
+    <child>
+      <object class="GtkImage">
+        <property name="icon-name">bookmark-new-symbolic</property>
+        <property name="use-fallback">yes</property>
+        <property name="visible">yes</property>
+      </object>
+    </child>
+  </template>
+</interface>


### PR DESCRIPTION
![screenshot from 2018-10-02 00-05-25](https://user-images.githubusercontent.com/1204189/46318574-47520c00-c5d7-11e8-9c94-beca57944bc7.png)

- Bookmarks can be added or edited via a toolbar button.
- Existing bookmarks will be suggested as completion items.
- `Midori.Database.update/ insert` become virtual.
- `Midori.Browser.uri` exposes URI without keeping track of tabs.
- Plugins in browser are called only after app is set.

Follow-ups:
- See #79 for bookmarks management in a panel

Closes: #40