### PR TITLE
Make dialogs opt-in or opt-out of header bars

### DIFF
--- a/core/browser.vala
+++ b/core/browser.vala
@@ -232,6 +232,7 @@ namespace Midori {
                 titlebar.unref ();
                 titlebar.get_style_context ().remove_class ("titlebar");
             } else {
+                get_settings ().gtk_dialogs_use_header = true;
                 Gtk.Settings.get_default ().notify["gtk-decoration-layout"].connect ((pspec) => {
                     update_decoration_layout ();
                 });

--- a/core/clear-private-data.vala
+++ b/core/clear-private-data.vala
@@ -24,10 +24,16 @@ namespace Midori {
         Cancellable? show_cancellable = null;
 
         public ClearPrivateData (Gtk.Window parent) {
-           Object (transient_for: parent,
-                   // Adding this property via GtkBuilder doesn't work
-                   // "for technical reasons, this property is declared as an integer"
-                   use_header_bar: 1);
+           Object (transient_for: parent);
+        }
+
+        construct {
+            if (get_settings ().gtk_dialogs_use_header) {
+                title = null;
+                // Adding this property via GtkBuilder doesn't work
+                // "for technical reasons, this property is declared as an integer"
+                use_header_bar = 1;
+            }
         }
 
         public override void show () {

--- a/ui/about.ui
+++ b/ui/about.ui
@@ -4,6 +4,8 @@
     <property name="logo-icon-name">midori</property>
     <property name="copyright">2007-2018 Christian Dywan</property>
     <property name="license-type">GTK_LICENSE_LGPL_2_1</property>
+    <property name="program-name" translatable="yes">Midori Web Browser</property>
     <property name="comments" translatable="yes">A lightweight web browser.</property>
+    <property name="translator-credits" translatable="yes">translator-credits</property>
   </template>
 </interface>

--- a/ui/clear-private-data.ui
+++ b/ui/clear-private-data.ui
@@ -1,6 +1,7 @@
 <interface>
   <template class="MidoriClearPrivateData" parent="GtkDialog">
     <property name="modal">yes</property>
+    <property name="title" translatable="yes">Clear Private Data</property>
     <child type="action">
       <object class="GtkButton" id="abort">
         <property name="label" translatable="yes">_Cancel</property>


### PR DESCRIPTION
- About gets Info and Credit tabs in a stack
- Clear Private Data gets Cancel and Clear Private Data
- gtk_dialogs_use_header also affects eg. print dialogs

Note:
- Shortcuts dialog doesn't support the trivial switch.