### PR TITLE
Port Status Clock to Peas API

### DIFF
--- a/core/browser.vala
+++ b/core/browser.vala
@@ -13,6 +13,7 @@ namespace Midori {
     public interface BrowserActivatable : Object {
         public abstract Browser browser { owned get; set; }
         public abstract void activate ();
+        public signal void deactivate ();
     }
 
     [GtkTemplate (ui = "/ui/browser.ui")]
@@ -69,7 +70,7 @@ namespace Midori {
         [GtkChild]
         Gtk.Stack tabs;
         [GtkChild]
-        Gtk.Overlay overlay;
+        public Gtk.Overlay overlay;
         [GtkChild]
         Statusbar statusbar;
         [GtkChild]

--- a/extensions/status-clock.plugin.in
+++ b/extensions/status-clock.plugin.in
@@ -1,0 +1,6 @@
+[Plugin]
+Module=status-clock
+IAge=3
+Icon=preferences-system-time-symbolic
+Name=Statusbar Clock
+Description=Display date and time in the statusbar

--- a/extensions/status-clock.vala
+++ b/extensions/status-clock.vala
@@ -1,0 +1,57 @@
+/*
+ Copyright (C) 2010 Arno Renevier <arno@renevier.net>
+ Copyright (C) 2018 Christian Dywan <christian@twotoasts.de>
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+
+ See the file COPYING for the full license text.
+*/
+
+namespace StatusClock {
+    public class Frontend : Object, Midori.BrowserActivatable {
+        public Midori.Browser browser { owned get; set; }
+
+        bool set_current_time (Gtk.Label clock) {
+            var date = new DateTime.now_local ();
+            string format = "%X";
+            clock.label = date.format (format);
+            int interval = format in "%s%N%s%S%T%X" ? 1 : int.max (60 - date.get_second (), 1);
+            Timeout.add_seconds (interval, () => {
+                set_current_time (clock);
+                return Source.REMOVE;
+            }, Priority.LOW);
+            return false;
+        }
+
+        public void activate () {
+            var clock = new Gtk.Label ("");
+            set_current_time (clock);
+            clock.halign = Gtk.Align.START;
+            clock.valign = Gtk.Align.START;
+            clock.set_padding (4, 4);
+            clock.margin = 4;
+            clock.get_style_context ().add_class ("background");
+            clock.show ();
+            browser.overlay.add_overlay (clock);
+            browser.overlay.enter_notify_event.connect ((event) => {
+                // Flip overlay to evade the mouse pointer
+                clock.hide ();
+                clock.halign = clock.halign == Gtk.Align.START ? Gtk.Align.END : Gtk.Align.START;
+                clock.show ();
+                return false;
+            });
+            deactivate.connect (() => {
+                clock.destroy ();
+            });
+        }
+    }
+}
+
+[ModuleInit]
+public void peas_register_types(TypeModule module) {
+    ((Peas.ObjectModule)module).register_extension_type (
+        typeof (Midori.BrowserActivatable), typeof (StatusClock.Frontend));
+}

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -26,6 +26,8 @@ core/tally.vala
 core/urlbar.vala
 extensions/bookmarks.plugin.in
 extensions/bookmarks.vala
+extensions/status-clock.plugin.in
+extensions/status-clock.vala
 ui/bookmarks-button.ui
 ui/browser.ui
 ui/clear-private-data.ui


### PR DESCRIPTION
A clock is displayed inside the browser. Unlike the previous version an
overlay is being used to add an evading label.

![screenshot from 2018-10-18 00-09-21](https://user-images.githubusercontent.com/1204189/47119392-fb57c600-d26a-11e8-9731-b26e901bf837.png)
![screenshot from 2018-10-18 00-10-58](https://user-images.githubusercontent.com/1204189/47119394-fdba2000-d26a-11e8-8996-a736e95b48ae.png)