### PR TITLE
Styling to visualize Private Browsing mode

### DIFF
--- a/data/gtk3.css
+++ b/data/gtk3.css
@@ -32,3 +32,11 @@
   padding: 0;
   margin: 0;
 }
+.incognito .split_headerbar {
+  background: transparent -gtk-icontheme("user-not-tracked-symbolic") 80% 30%/auto 160% no-repeat, linear-gradient(to left, #81ca45 8%, #4da80d 25%);
+  color: rgba(0, 0, 0, 0.3);
+}
+.incognito .split_headerbar * {
+  background: transparent;
+  color: #eee;
+}

--- a/ui/browser.ui
+++ b/ui/browser.ui
@@ -21,6 +21,9 @@
       <object class="GtkPaned">
         <property name="visible">yes</property>
         <property name="position" bind-source="paned" bind-property="position" bind-flags="bidirectional|sync-create"/>
+        <style>
+          <class name="split_headerbar"/>
+        </style>
         <child>
           <object class="GtkHeaderBar" id="panelbar">
             <property name="show-close-button">yes</property>


### PR DESCRIPTION
The state of a private window is distinguished by
coloring the split headerbar and showing an icon.

![screenshot from 2018-10-18 00-40-13](https://user-images.githubusercontent.com/1204189/47120334-838b9a80-d26e-11e8-891d-5fed862718bd.png)