### PR TITLE
Merge translations into plugin descriptions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,8 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 # Disallow building during install to avoid permission problems
 set(CMAKE_SKIP_INSTALL_ALL_DEPENDENCY 1)
 
+include(FindIntltool)
+
 find_package(Vala REQUIRED)
 vala_require("0.30.0")
 set(VALAFLAGS ${VALAFLAGS}

--- a/cmake/FindIntltool.cmake
+++ b/cmake/FindIntltool.cmake
@@ -5,16 +5,16 @@
 # Copyright (C) 2013-2018 Christian Dywan
 
 find_program (INTLTOOL_MERGE_EXECUTABLE intltool-merge)
-find_program (INTLTOOL_UPDATE_EXECUTABLE intltool-update)
-
 if (INTLTOOL_MERGE_EXECUTABLE)
-    set (INTLTOOL_MERGE_FOUND TRUE)
-    macro (INTLTOOL_MERGE_DESKTOP desktop_id po_dir)
-        add_custom_target (${desktop_id}.desktop ALL
+    macro (INTLTOOL_MERGE_DESKTOP_LIKE target po_dir)
+        add_custom_target (${target} ALL
             COMMAND ${INTLTOOL_MERGE_EXECUTABLE} --desktop-style ${CMAKE_SOURCE_DIR}/${po_dir}
-                ${CMAKE_CURRENT_SOURCE_DIR}/${desktop_id}.desktop.in ${desktop_id}.desktop
-            DEPENDS ${desktop_id}.desktop.in
+                ${CMAKE_CURRENT_SOURCE_DIR}/${target}.in ${target}
+            DEPENDS ${target}.in
         )
+    endmacro (INTLTOOL_MERGE_DESKTOP_LIKE target po_dir)
+    macro (INTLTOOL_MERGE_DESKTOP desktop_id po_dir)
+        INTLTOOL_MERGE_DESKTOP_LIKE ("${desktop_id}.desktop" ${po_dir})
         install (FILES "${CMAKE_CURRENT_BINARY_DIR}/${desktop_id}.desktop"
                  DESTINATION "${CMAKE_INSTALL_PREFIX}/share/applications")
     endmacro (INTLTOOL_MERGE_DESKTOP desktop_id po_dir)
@@ -27,14 +27,16 @@ if (INTLTOOL_MERGE_EXECUTABLE)
         install (FILES "${CMAKE_CURRENT_BINARY_DIR}/${desktop_id}.appdata.xml"
                  DESTINATION "${CMAKE_INSTALL_PREFIX}/share/appdata")
     endmacro (INTLTOOL_MERGE_APPDATA desktop_id po_dir)
+else ()
+    message(FATAL_ERROR "intltool-merge not found")
 endif ()
 
+find_program (INTLTOOL_UPDATE_EXECUTABLE intltool-update)
 if (INTLTOOL_UPDATE_EXECUTABLE)
-    set (INTLTOOL_UPDATE_FOUND TRUE)
     add_custom_target (pot
         COMMAND ${INTLTOOL_UPDATE_EXECUTABLE} "-p" "-g" ${GETTEXT_PACKAGE}
         WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/po"
         )
+else ()
+    message(FATAL_ERROR "intltool-update not found")
 endif ()
-
-

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -5,13 +5,6 @@ if (NOT XMLLINT_EXECUTABLE)
     message(FATAL_ERROR "xmllint not found")
 endif ()
 
-include(FindIntltool)
-if (NOT INTLTOOL_MERGE_FOUND)
-    message(FATAL_ERROR "intltool-merge not found")
-elseif (NOT INTLTOOL_UPDATE_FOUND)
-    message(FATAL_ERROR "intltool-update not found")
-endif ()
-
 file(GLOB_RECURSE DATA_FILES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *)
 list(REMOVE_ITEM DATA_FILES "CMakeLists.txt")
 

--- a/extensions/CMakeLists.txt
+++ b/extensions/CMakeLists.txt
@@ -46,7 +46,7 @@ foreach(UNIT_SRC ${EXTENSIONS})
             LIBRARY DESTINATION ${EXTENSIONDIR}
             )
     set(MANIFEST "${UNIT}.plugin")
-    configure_file(${MANIFEST}.in ${MANIFEST})
+    INTLTOOL_MERGE_DESKTOP_LIKE (${MANIFEST} po)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${MANIFEST}
             DESTINATION ${EXTENSIONDIR}
             )

--- a/extensions/bookmarks.plugin.in
+++ b/extensions/bookmarks.plugin.in
@@ -2,5 +2,6 @@
 Module=bookmarks
 IAge=3
 Builtin=true
-Name=Bookmarks
-Description=Show the saved bookmarks
+Icon=user-bookmarks-symbolic
+_Name=Bookmarks
+_Description=Show the saved bookmarks

--- a/extensions/status-clock.plugin.in
+++ b/extensions/status-clock.plugin.in
@@ -2,5 +2,5 @@
 Module=status-clock
 IAge=3
 Icon=preferences-system-time-symbolic
-Name=Statusbar Clock
-Description=Display date and time in the statusbar
+_Name=Statusbar Clock
+_Description=Display date and time in the statusbar


### PR DESCRIPTION
Plugin descriptions are basically `.desktop` files and Peas supports picking up locale-specific keys suffixed with `[language]` which means keys prefixed with an underscore in the `.plugin.in` can be extracted.