### PR TITLE
Port Tab Panel to Peas API

### DIFF
--- a/core/settings.vala
+++ b/core/settings.vala
@@ -34,6 +34,12 @@ namespace Midori {
             set_boolean ("extensions", "lib%s.so".printf (plugin), enabled);
         }
 
+        public bool show_panel { get {
+            return get_boolean ("settings", "show-panel", false);
+        } set {
+            set_boolean ("settings", "show-panel", value, false);
+        } }
+
         public bool enable_spell_checking { get {
             return get_boolean ("settings", "enable-spell-checking", true);
         } set {

--- a/core/switcher.vala
+++ b/core/switcher.vala
@@ -13,7 +13,7 @@ namespace Midori {
     public class Switcher : Gtk.Box {
         HashTable<Gtk.Widget, Tally> buttons;
         public Gtk.Stack? stack { get; set; }
-        public bool show_close_buttons { get; protected set; }
+        internal bool show_close_buttons { get; protected set; }
 
         construct {
             buttons = new HashTable<Gtk.Widget, Tally> (direct_hash, direct_equal);

--- a/data/gtk3.css
+++ b/data/gtk3.css
@@ -28,6 +28,9 @@
 .titlebar .tab:only-child {
   box-shadow: none;
 }
+.tab image, .tab spinner {
+  padding: 0 2px;
+}
 .tab button {
   padding: 0;
   margin: 0;

--- a/extensions/tab-panel.plugin.in
+++ b/extensions/tab-panel.plugin.in
@@ -1,0 +1,6 @@
+[Plugin]
+Module=tab-panel
+IAge=3
+Icon=view-list-symbolic
+_Name=Tab Panel
+_Description=Show tabs in a vertical panel

--- a/extensions/tab-panel.vala
+++ b/extensions/tab-panel.vala
@@ -1,0 +1,34 @@
+/*
+ Copyright (C) 2008-2018 Christian Dywan <christian@twotoasts.de>
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+
+ See the file COPYING for the full license text.
+*/
+
+namespace TabPanel {
+    public class Frontend : Object, Midori.BrowserActivatable {
+        public Midori.Browser browser { owned get; set; }
+
+        public void activate () {
+            var switcher = new Midori.Switcher ();
+            switcher.stack = browser.tabs;
+            switcher.orientation = Gtk.Orientation.VERTICAL;
+            switcher.show ();
+            browser.panel.add_titled (switcher, "tab-panel", _("Tab Panel"));
+            browser.panel.child_set (switcher, "icon-name", "view-list-symbolic");
+            deactivate.connect (() => {
+                switcher.destroy ();
+            });
+        }
+    }
+}
+
+[ModuleInit]
+public void peas_register_types(TypeModule module) {
+    ((Peas.ObjectModule)module).register_extension_type (
+        typeof (Midori.BrowserActivatable), typeof (TabPanel.Frontend));
+}

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -28,6 +28,8 @@ extensions/bookmarks.plugin.in
 extensions/bookmarks.vala
 extensions/status-clock.plugin.in
 extensions/status-clock.vala
+extensions/tab-panel.plugin.in
+extensions/tab-panel.vala
 ui/bookmarks-button.ui
 ui/browser.ui
 ui/clear-private-data.ui

--- a/ui/tally.ui
+++ b/ui/tally.ui
@@ -7,6 +7,7 @@
       <object class="GtkBox">
         <property name="orientation">horizontal</property>
         <property name="visible">yes</property>
+        <property name="hexpand">yes</property>
         <child>
           <object class="MidoriFavicon" id="favicon">
             <!-- menu -->
@@ -27,6 +28,7 @@
             <!-- As per docs, when ellipsized and expanded max width is the minimum -->
             <property name="width-chars">8</property>
             <property name="max-width-chars">500</property>
+            <property name="hexpand">yes</property>
             <property name="visible">yes</property>
           </object>
         </child>


### PR DESCRIPTION
A vertical list of tabs, trivially implemented thanks to `Gtk.Stack`.

![screenshot from 2018-10-18 20-30-49](https://user-images.githubusercontent.com/1204189/47176156-2bf43a00-d315-11e8-9105-f90ca161fd10.png)
