### PR TITLE
More robust download handling

### DIFF
--- a/core/browser.vala
+++ b/core/browser.vala
@@ -258,6 +258,7 @@ namespace Midori {
                 update_decoration_layout ();
             }
 
+            downloads.web_context = web_context;
             if (web_context.is_ephemeral ()) {
                 get_style_context ().add_class ("incognito");
             }

--- a/ui/download-row.ui
+++ b/ui/download-row.ui
@@ -43,6 +43,11 @@
             </child>
             <child>
               <object class="GtkLabel" id="status">
+                <property name="ellipsize">end</property>
+                <property name="xalign">0.0</property>
+                <property name="hexpand">yes</property>
+                <!-- As per docs, when ellipsized and expanded max width is the minimum -->
+                <property name="max-width-chars">1</property>
                 <property name="visible">yes</property>
               </object>
             </child>


### PR DESCRIPTION
More robust download handling

- Using `SYNC_CREATE` for property bindings
- Deduplicating state updating code
- Replacing `bool failed` with `string? error` to be shown in a `Gtk.Label`
- Using the appropriate `WebContext` from `Browser`

Fixes: #126