### PR TITLE
Add combo box to pick default search engine

### DIFF
--- a/core/preferences.vala
+++ b/core/preferences.vala
@@ -96,6 +96,16 @@ namespace Midori {
             box.show_all ();
             add (_("Browsing"), box);
 
+            box = new LabelWidget (_("Search _with"));
+            var combo = new Gtk.ComboBoxText ();
+            combo.append ("https://duckduckgo.com/?q=%s", "Duck Duck Go");
+            combo.append ("http://search.yahoo.com/search?p=", "Yahoo");
+            combo.append ("http://www.google.com/search?q=%s", "Google");
+            settings.bind_property ("location-entry-search", combo, "active-id", BindingFlags.SYNC_CREATE | BindingFlags.BIDIRECTIONAL);
+            box.add (combo);
+            box.show_all ();
+            add (_("Browsing"), box);
+
             box = new LabelWidget (_("_Tabs"));
             var entry = new Gtk.SearchEntry ();
             entry.primary_icon_name = null;


### PR DESCRIPTION
Basic picker for the default search engine to be used from the urlbar or when right-clicking to search for the selected text.

![screenshot from 2018-10-22 12-05-57](https://user-images.githubusercontent.com/1204189/47287577-073ce280-d5f3-11e8-8c8d-2c0222ad5b6a.png)