### PR TITLE
Revert to existing strings for menus and shortcuts

### DIFF
--- a/ui/clear-private-data.ui
+++ b/ui/clear-private-data.ui
@@ -4,8 +4,8 @@
     <property name="title" translatable="yes">Clear Private Data</property>
     <child type="action">
       <object class="GtkButton" id="abort">
-        <property name="label" translatable="yes">C_ancel</property>
-        <property name="use-underline">yes</property>
+        <property name="label">gtk-cancel</property>
+        <property name="use-stock">yes</property>
         <property name="visible">yes</property>
       </object>
     </child>

--- a/ui/menus.ui
+++ b/ui/menus.ui
@@ -30,8 +30,7 @@
       <item>
         <attribute name="action">win.show-help-overlay</attribute>
         <attribute name="hidden-when">action-disabled</attribute>
-        <attribute name="label" translatable="yes">_Shortcuts</attribute>
-        <attribute name="accel">&lt;Primary&gt;&lt;Alt&gt;s</attribute>
+        <attribute name="label" translatable="yes">Shortcuts</attribute>
       </item>
       <item>
         <attribute name="action">win.about</attribute>
@@ -39,7 +38,7 @@
       </item>
       <item>
         <attribute name="action">app.quit</attribute>
-        <attribute name="label" translatable="yes">_Quit</attribute>
+        <attribute name="label" translatable="yes">Close a_ll Windows</attribute>
         <attribute name="accel">&lt;Primary&gt;q</attribute>
       </item>
     </section>
@@ -48,17 +47,17 @@
     <section>
       <item>
         <attribute name="action">win.find</attribute>
-        <attribute name="label" translatable="yes">_Find in Page</attribute>
+        <attribute name="label" translatable="yes">_Find…</attribute>
         <attribute name="accel">&lt;Primary&gt;f</attribute>
       </item>
       <item>
         <attribute name="action">win.view-source</attribute>
         <attribute name="label" translatable="yes">View So_urce</attribute>
-        <attribute name="accel">&lt;Primary&gt;&lt;Alt&gt;u</attribute>
+        <attribute name="accel">&lt;Primary&gt;u</attribute>
       </item>
       <item>
         <attribute name="action">win.print</attribute>
-        <attribute name="label" translatable="yes">_Print…</attribute>
+        <attribute name="label" translatable="yes">Print the current page</attribute>
         <attribute name="accel">&lt;Primary&gt;p</attribute>
       </item>
     </section>
@@ -68,12 +67,14 @@
       <item>
         <attribute name="action">tally.pin</attribute>
         <attribute name="hidden-when">action-disabled</attribute>
-        <attribute name="label" translatable="yes">_Pin Tab</attribute>
+        <attribute name="label" translatable="yes">Show Tab _Icon Only</attribute>
       </item>
+    </section>
+    <section>
       <item>
         <attribute name="action">tally.unpin</attribute>
         <attribute name="hidden-when">action-disabled</attribute>
-        <attribute name="label" translatable="yes">Unpin Ta_b</attribute>
+        <attribute name="label" translatable="yes">Show Tab _Label</attribute>
       </item>
     </section>
   </menu>

--- a/ui/shortcuts.ui
+++ b/ui/shortcuts.ui
@@ -1,6 +1,5 @@
 <interface>
   <object class="GtkShortcutsWindow" id="help_overlay">
-    <property name="modal">no</property>
     <child>
       <object class="GtkShortcutsSection">
         <property name="visible">yes</property>
@@ -52,14 +51,14 @@
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="accelerator">&lt;Primary&gt;r</property>
-                <property name="title" translatable="yes">Reload current page</property>
+                <property name="title" translatable="yes">Reload the current page</property>
                 <property name="visible">yes</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="accelerator">Escape</property>
-                <property name="title" translatable="yes">Stop loading</property>
+                <property name="title" translatable="yes">Stop loading the current page</property>
                 <property name="visible">yes</property>
               </object>
             </child>
@@ -73,14 +72,14 @@
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="accelerator">&lt;Alt&gt;Left</property>
-                <property name="title" translatable="yes">Go back to previous page</property>
+                <property name="title" translatable="yes">Go back to the previous page</property>
                 <property name="visible">yes</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="accelerator">&lt;Alt&gt;Right</property>
-                <property name="title" translatable="yes">Go to next page</property>
+                <property name="title" translatable="yes">Go forward to next page</property>
                 <property name="visible">yes</property>
               </object>
             </child>
@@ -88,12 +87,19 @@
         </child>
         <child>
           <object class="GtkShortcutsGroup">
-            <property name="title" translatable="yes">Windows</property>
+            <property name="title" translatable="yes">Browser window</property>
             <property name="visible">yes</property>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="accelerator">&lt;Primary&gt;n</property>
                 <property name="title" translatable="yes">New Window</property>
+                <property name="visible">yes</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="accelerator">&lt;Primary&gt;&lt;Shift&gt;p</property>
+                <property name="title" translatable="yes">New Private Browsing Window</property>
                 <property name="visible">yes</property>
               </object>
             </child>
@@ -122,26 +128,26 @@
         </child>
         <child>
           <object class="GtkShortcutsGroup">
-            <property name="title" translatable="yes">Page</property>
+            <property name="title" translatable="yes">View</property>
             <property name="visible">yes</property>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="accelerator">&lt;Primary&gt;plus</property>
-                <property name="title" translatable="yes">Zoom in</property>
+                <property name="title" translatable="yes">Increase the zoom level</property>
                 <property name="visible">yes</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="accelerator">&lt;Primary&gt;minus</property>
-                <property name="title" translatable="yes">Zoom out</property>
+                <property name="title" translatable="yes">Decrease the zoom level</property>
                 <property name="visible">yes</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="accelerator">&lt;Primary&gt;0</property>
-                <property name="title" translatable="yes">Reset zoom level</property>
+                <property name="title" translatable="yes">Default Zoom Level</property>
                 <property name="visible">yes</property>
               </object>
             </child>
@@ -156,6 +162,13 @@
               <object class="GtkShortcutsShortcut">
                 <property name="accelerator">&lt;Primary&gt;u</property>
                 <property name="title" translatable="yes">View page source</property>
+                <property name="visible">yes</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="accelerator">&lt;Primary&gt;p</property>
+                <property name="title" translatable="yes">Print the current page</property>
                 <property name="visible">yes</property>
               </object>
             </child>

--- a/ui/urlbar.ui
+++ b/ui/urlbar.ui
@@ -19,7 +19,7 @@
         <property name="visible">yes</property>
         <child>
           <object class="GtkLabel" id="security_status">
-            <property name="label" translatable="yes">Connection is not secure</property>
+            <property name="label" translatable="yes">Security unknown</property>
           </object>
         </child>
       </object>


### PR DESCRIPTION
With a new translation setup pending (see #85) it should be a good idea to re-use existing strings as much as possible.