### PR TITLE
Implement caret browsing toggle via F7

### DIFF
--- a/core/browser.vala
+++ b/core/browser.vala
@@ -44,6 +44,7 @@ namespace Midori {
             { "find", find_activated },
             { "view-source", view_source_activated },
             { "print", print_activated },
+            { "caret-browsing", caret_browsing_activated },
             { "show-inspector", show_inspector_activated },
             { "clear-private-data", clear_private_data_activated },
             { "preferences", preferences_activated },
@@ -116,6 +117,7 @@ namespace Midori {
                 application.set_accels_for_action ("win.find", { "<Primary>f", "slash" });
                 application.set_accels_for_action ("win.view-source", { "<Primary>u", "<Primary><Alt>u" });
                 application.set_accels_for_action ("win.print", { "<Primary>p" });
+                application.set_accels_for_action ("win.caret-browsing", { "F7" });
                 application.set_accels_for_action ("win.show-inspector", { "<Primary><Shift>i" });
                 application.set_accels_for_action ("win.goto", { "<Primary>l", "F7" });
                 application.set_accels_for_action ("win.go-back", { "<Alt>Left", "BackSpace" });
@@ -470,6 +472,31 @@ namespace Midori {
 
         void print_activated () {
             tab.print (new WebKit.PrintOperation (tab));
+        }
+
+        void caret_browsing_activated () {
+            var settings = CoreSettings.get_default ();
+            if (!settings.enable_caret_browsing) {
+                var dialog = new Gtk.Dialog.with_buttons (
+                    get_settings ().gtk_dialogs_use_header ? null : _("Toggle text cursor navigation"),
+                    this,
+                    get_settings ().gtk_dialogs_use_header ? Gtk.DialogFlags.USE_HEADER_BAR : 0,
+                    Gtk.Stock.CANCEL, Gtk.ResponseType.CANCEL,
+                    _("_Enable Caret Browsing"), Gtk.ResponseType.ACCEPT);
+                var label = new Gtk.Label (_("Pressing F7 toggles Caret Browsing. When active, a text cursor appears in all websites."));
+                label.wrap = true;
+                label.max_width_chars = 33;
+                label.margin = 8;
+                label.show ();
+                dialog.get_content_area ().add (label);
+                dialog.set_default_response (Gtk.ResponseType.ACCEPT);
+                if (dialog.run () == Gtk.ResponseType.ACCEPT) {
+                    settings.enable_caret_browsing = true;
+                }
+                dialog.close ();
+            } else {
+                settings.enable_caret_browsing = false;
+            }
         }
 
         void show_inspector_activated () {

--- a/core/settings.vala
+++ b/core/settings.vala
@@ -54,6 +54,11 @@ namespace Midori {
         } set {
             set_boolean ("settings", "enable-plugins", value, true);
         } }
+        public bool enable_caret_browsing { get {
+            return get_boolean ("settings", "enable-caret-browsing", false);
+        } set {
+            set_boolean ("settings", "enable-caret-browsing", value, false);
+        } }
 
         public bool close_buttons_on_tabs { get {
             return get_boolean ("settings", "close-buttons-on-tabs", true);

--- a/core/tab.vala
+++ b/core/tab.vala
@@ -67,6 +67,7 @@ namespace Midori {
             core_settings.notify["enable-javascript"].connect ((pspec) => {
                 settings.enable_javascript = core_settings.enable_javascript;
             });
+            core_settings.bind_property ("enable-caret-browsing", settings, "enable-caret-browsing", BindingFlags.SYNC_CREATE);
 
             if (uri != null) {
                 display_uri = uri;

--- a/ui/shortcuts.ui
+++ b/ui/shortcuts.ui
@@ -84,6 +84,13 @@
                 <property name="visible">yes</property>
               </object>
             </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="accelerator">F7</property>
+                <property name="title" translatable="yes">Toggle text cursor navigation</property>
+                <property name="visible">yes</property>
+              </object>
+            </child>
           </object>
         </child>
         <child>


### PR DESCRIPTION
This accessibility feature works simply: F7 enables a caret for the entire website that's normally limited to editable elements. A confirmation dialog is shown to avoid confusion when accidentally enabling it.

![screenshot from 2018-10-22 18-37-58](https://user-images.githubusercontent.com/1204189/47305571-273bc880-d62a-11e8-85b1-c590d5511d5a.png)
