### PR TITLE
Make the Clear Private Data dialog fixed size

### DIFF
--- a/ui/clear-private-data.ui
+++ b/ui/clear-private-data.ui
@@ -1,6 +1,7 @@
 <interface>
   <template class="MidoriClearPrivateData" parent="GtkDialog">
     <property name="modal">yes</property>
+    <property name="resizable">no</property>
     <property name="title" translatable="yes">Clear Private Data</property>
     <child type="action">
       <object class="GtkButton" id="abort">


### PR DESCRIPTION
Changing the size of the dialog is at best confusing.

This is a trivial tweak that came out of some informal user testing.