### PR TITLE
Update spinner position according to close button

### DIFF
--- a/core/tally.vala
+++ b/core/tally.vala
@@ -100,9 +100,11 @@ namespace Midori {
             if (layout.index_of ("c") < layout.index_of (":")) {
                 box.reorder_child (close, 0);
                 box.reorder_child (favicon, -1);
+                box.reorder_child (spinner, -1);
             } else {
                 box.reorder_child (close, -1);
                 box.reorder_child (favicon, 0);
+                box.reorder_child (spinner, 0);
             }
         }
 


### PR DESCRIPTION
Small bug fix: the spinner isn't moved when the close button and favicon are moved around according to the position of the close button.