### PR TITLE
Revised tabbar styling and organized stylesheet

### DIFF
--- a/core/tally.vala
+++ b/core/tally.vala
@@ -110,7 +110,7 @@ namespace Midori {
 
         void update_visibility () {
             caption.visible = !(tab.pinned && _show_close);
-            close.visible = _show_close && !tab.pinned && CoreSettings.get_default ().close_buttons_on_tabs;
+            close.visible = !tab.pinned && CoreSettings.get_default ().close_buttons_on_tabs;
         }
 
         construct {

--- a/data/gtk3.css
+++ b/data/gtk3.css
@@ -9,29 +9,78 @@
  See the file COPYING for the full license text.
 */
 
+/* Tab styling */
+.tab box {
+  margin: 0 4px;
+  padding: 4px 4px;
+}
 .tab:not(:checked) {
   opacity: 0.7;
 }
 .tab:hover {
-  box-shadow: inset 0 3px darker(@theme_selected_bg_color);
+  box-shadow: inset 0 3px darker(@theme_selected_bg_color),
+              inset 0 -1px @borders;
 }
 .tab:checked {
   box-shadow: inset 0 3px @theme_selected_bg_color;
-  font-weight: bold;
 }
 .tab label {
   text-shadow: none;
 }
-.tab:backdrop {
-  border: none;
-}
-.titlebar .tab:only-child {
-  box-shadow: none;
-}
-.tab button {
+
+/* No padding around close buttons */
+.tab .close {
   padding: 0;
   margin: 0;
 }
+
+/* Visually merge active tab label with navigationbar */
+.split_headerbar {
+  padding-bottom: 0;
+}
+.split_headerbar, headerbar {
+  border-bottom-width: 0;
+}
+headerbar {
+  box-shadow: inset 0 -1px @theme_bg_color;
+}
+.navigationbar, .navigationbar box {
+  border-top-width: 0;
+  background: transparent;
+}
+.tabbar {
+  box-shadow: inset 0 -2px @theme_bg_color;
+}
+
+/* Active tab label styling */
+.titlebar .tab:checked:not(:only-child),
+.split_headerbar:not(.titlebar) .tab:checked {
+  box-shadow: inset 0 3px @theme_selected_bg_color;
+  border-left: 1px solid @borders;
+  border-right: 1px solid @borders;
+  background-color: @theme_bg_color;
+}
+.titlebar:backdrop .tab:checked:not(:only-child),
+.split_headerbar:not(.titlebar):backdrop .tab:checked {
+  border-left: 1px solid alpha(@borders, 0.5);
+  border-right: 1px solid alpha(@borders, 0.5);
+}
+.titlebar .tab:checked:not(:only-child) *,
+.split_headerbar:not(.titlebar) .tab:checked * {
+  color: @theme_fg_color;
+}
+
+/* A single tab should really just be a label */
+.titlebar .tab:only-child {
+  box-shadow: none;
+}
+.titlebar .tab:only-child image,
+.titlebar .tab:only-child spinner,
+.titlebar .tab:only-child button {
+  opacity: 0.0;
+}
+
+/* Visible indication of private browsing */
 .incognito .split_headerbar {
   background: transparent -gtk-icontheme("user-not-tracked-symbolic") 80% 30%/auto 160% no-repeat, linear-gradient(to left, #81ca45 8%, #4da80d 25%);
   color: rgba(0, 0, 0, 0.3);
@@ -39,7 +88,15 @@
 .incognito .split_headerbar * {
   background: transparent;
   color: #eee;
+}
+
+/* Overlay statusbar */
 statusbar button {
   margin: 4px;
   padding: 0 4px;
+}
+
+/* Emphasize security indicator */
+.urlbar image.left {
+  color: @theme_selected_bg_color;
 }

--- a/ui/browser.ui
+++ b/ui/browser.ui
@@ -129,6 +129,9 @@
                 <property name="pack-type">end</property>
               </packing>
             </child>
+            <style>
+              <class name="tabbar"/>
+            </style>
           </object>
           <packing>
             <property name="shrink">no</property>

--- a/ui/navigationbar.ui
+++ b/ui/navigationbar.ui
@@ -120,5 +120,8 @@
         <property name="pack-type">end</property>
       </packing>
     </child>
+    <style>
+      <class name="navigationbar"/>
+    </style>
   </template>
 </interface>

--- a/ui/tally.ui
+++ b/ui/tally.ui
@@ -12,13 +12,11 @@
             <!-- menu -->
             <property name="icon-size">1</property>
             <property name="visible">yes</property>
-            <property name="margin-right">4</property>
           </object>
         </child>
         <child>
           <object class="GtkSpinner" id="spinner">
             <property name="active">yes</property>
-            <property name="margin-right">4</property>
           </object>
         </child>
         <child>
@@ -44,6 +42,9 @@
                 <property name="visible">yes</property>
               </object>
             </child>
+            <style>
+                <class name="close"/>
+            </style>
           </object>
         </child>
       </object>

--- a/ui/urlbar.ui
+++ b/ui/urlbar.ui
@@ -28,5 +28,8 @@
   <template class="MidoriUrlbar" parent="GtkEntry">
     <property name="can-default">yes</property>
     <property name="placeholder-text" translatable="yes">Search or enter an address</property>
+    <style>
+      <class name="urlbar"/>
+    </style>
   </template>
 </interface>


### PR DESCRIPTION
- Handle single tab titlebar case completely in CSS
- Distinct active tab style
- Visually merge active tab and navigationbar
- Add style classes `close`, `tabbar`, `navigationbar` and `urlbar`
- Comments to explain stylesheet effects

![screenshot from 2018-10-26 15-30-16](https://user-images.githubusercontent.com/1204189/47569552-2d84ba00-d934-11e8-8d80-e1339e6b9bbb.png)

Note:
 - There's a visual glitch with the Elementary theme because it relies on bottom-padding in the titlebar (no other themes do afair):

![screenshot from 2018-10-26 15-33-47](https://user-images.githubusercontent.com/1204189/47569711-979d5f00-d934-11e8-9098-f7fe49557400.png)
