### PR TITLE
Changed {width,height} of shortcut image to max-{width,height}.

### DIFF
--- a/data/about.css
+++ b/data/about.css
@@ -97,8 +97,8 @@ button {
 }
 
 .shortcut a img {
-    width: 50%;
-    height: 50%;
+    max-width: 50%;
+    max-height: 50%;
     margin: auto;
     margin-bottom: .5em;
     display: block;


### PR DESCRIPTION
Rationale: Icons do not look good when scaled up too much. Giving both width and height distorts the icon.

Fixes: #206