### PR TITLE
Hide timerange combo from Clear Private Data dialog

### DIFF
--- a/ui/clear-private-data.ui
+++ b/ui/clear-private-data.ui
@@ -36,7 +36,6 @@
           <object class="GtkBox">
             <property name="orientation">horizontal</property>
             <property name="spacing">4</property>
-            <property name="visible">yes</property>
             <child>
               <object class="GtkLabel" id="timerange_label">
                 <property name="label" translatable="yes">_Time range to clear</property>
@@ -46,7 +45,7 @@
             </child>
             <child>
               <object class="GtkComboBoxText" id="timerange">
-                <property name="active-id">last-hour</property>
+                <property name="active-id">0</property>
                 <property name="visible">yes</property>
                 <items>
                   <item id="0" translatable="yes">Clear all</item>


### PR DESCRIPTION

![screenshot from 2018-10-30 14-59-33](https://user-images.githubusercontent.com/1204189/47723521-f6284d00-dc54-11e8-850d-f2e7a372ef11.png)
The user experience of selecting a specific timespan needs
more discussion, and for the moment we don't lose anything
by going back to clearing everything.