### PR TITLE
Don't modify the urlbar text based on the selected row

### DIFF
--- a/core/urlbar.vala
+++ b/core/urlbar.vala
@@ -23,6 +23,7 @@ namespace Midori {
             location = value;
             // Treat about:blank specially
             text = blank ? "" : value;
+            set_position (-1);
             update_icon ();
         } }
         bool _secure = false;
@@ -52,17 +53,6 @@ namespace Midori {
             });
 
             listbox.row_selected.connect ((row) => {
-                if (row != null && selected_row != row) {
-                    var suggestion_row = (SuggestionRow)row;
-                    string? new_text = suggestion_row.item.uri;
-                    if (suggestion_row.item is SuggestionItem) {
-                        new_text = key;
-                    }
-                    if (new_text != null && new_text != text) {
-                        text = new_text;
-                        set_position (-1);
-                    }
-                }
                 selected_row = row;
             });
             listbox.row_activated.connect ((row) => {
@@ -160,6 +150,7 @@ namespace Midori {
                     return true;
                 case Gdk.Key.Escape:
                     text = blank ? "" : uri;
+                    set_position (-1);
                     // Propagate to allow Escape to stop loading
                     return false;
             }


### PR DESCRIPTION
I'm in two minds on this one. Modifying the urlbar based on the selected row is what's causing surprising behavior in some cases. Leaving the entry alone fixes that at the cost of not showing explicitly what url is going to be opened.

Fixes: #117 