### PR TITLE
Release Midori 6.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,14 +9,14 @@ add_definitions("-DGETTEXT_PACKAGE=\"${GETTEXT_PACKAGE}\"")
 project(${GETTEXT_PACKAGE} C)
 set(PROJECT_BUGS https://github.com/midori-browser/core/issues)
 set(PROJECT_WEBSITE https://www.midori-browser.org)
-set(CORE_VERSION 0.6.0)
+set(CORE_VERSION 6.0)
 
 execute_process(COMMAND "git" "describe" "--tags"
                 OUTPUT_VARIABLE REVISION
                 ERROR_QUIET
                 OUTPUT_STRIP_TRAILING_WHITESPACE)
 if (REVISION)
-    set(CORE_VERSION "${CORE_VERSION}~r${REVISION}")
+    set(CORE_VERSION "${REVISION}")
     # All warnings are errors in development builds
     set(VALAFLAGS ${VALAFLAGS} --fatal-warnings)
 else ()

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+v6.0
+ Revamped Vala-only core based on GTK+3 and WebKit2
+ App based on Gtk.Application, supporting global/ window app menu
+ Tabs on top with a custom stack switcher and Gtk.Stack
+ Url completion with GLib.ListModel and Gtk.ListBox
+ Peas-based extensions, also available in Private Browsing
+_New fullscreen mode with auto-revealing toolbar
+
 v0.5.11
  Add fake theme for built-in icons
  * Don't truncate long speed dial titles if there's room to display them

--- a/README.md
+++ b/README.md
@@ -98,6 +98,20 @@ You'll want to **unit test** the code if you're testing a new version or contrib
 * `javascript:alert("test")`, `javascript:confirm("test")` and `javascript:input("test")` work
 * Websites can (un)toggle fullscreen mode
 
+# Release process
+
+Update `CORE_VERSION` in `CMakeLists.txt` to `6.0`.
+Add a section to `ChangeLog`.
+
+    git commit -p -v -m "Release Midori 6.0"
+    git checkout -B release-6.0
+    git push origin HEAD
+    git archive -o midori-v6.0.tar.gz -9 HEAD
+
+Propose a PR for the release.
+Publish the release on https://github.com/midori-browser/core/releases
+Promote snap on https://snapcraft.io/midori/release to the `stable` channel
+
 # Troubleshooting
 
 Testing an installed release may reveal crashers or memory corruption which require investigating from a local build and obtaining a stacktrace (backtrace, crash log).

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -3,8 +3,7 @@ version: git
 version-script: |
   set -x
   VERSION=$(grep -r "^set(CORE_VERSION" CMakeLists.txt | sed -r "s@.+ ([0-9.]+)\)@\1@")
-  REVISION=$(git describe --tags)
-  echo $VERSION~r$REVISION
+  echo $(git describe --tags || echo $VERSION)
 summary: a lightweight, fast, and free web browser
 description: |
   Midori is a lightweight yet powerful web browser which runs just as well on little embedded computers named for delicious pastries as it does on beefy machines with a core temperature exceeding that of planet earth. And it looks good doing that, too. Oh, and of course it's free software.


### PR DESCRIPTION
- Bump top `6.0`
- Updated `ChangeLog`
- Steps to release in `README.md`
- Updated CMake/ snap to take revision or version only