### PR TITLE
Highlight finished download(s) via style class

### DIFF
--- a/core/download-button.vala
+++ b/core/download-button.vala
@@ -13,6 +13,7 @@ namespace Midori {
     [GtkTemplate (ui = "/ui/download-button.ui")]
     public class DownloadButton : Gtk.Button {
         public virtual signal void show_downloads () {
+            get_style_context ().remove_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
             popover.show ();
         }
 
@@ -40,7 +41,11 @@ namespace Midori {
             if (download.destination != null && download.destination.has_prefix (cache)) {
                 return;
             }
-            model.append (new DownloadItem.with_download (download));
+            var item = new DownloadItem.with_download (download);
+            item.finished.connect (() => {
+                get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
+            });
+            model.append (item);
         }
 
         public Gtk.Widget create_row (Object item) {
@@ -79,6 +84,7 @@ namespace Midori {
                 loading = false;
             }
         }
+        public signal void finished ();
 
         construct {
             notify["filename"].connect ((pspec) => {
@@ -104,6 +110,7 @@ namespace Midori {
             download.finished.connect (() => {
                 download = null;
                 loading = false;
+                finished ();
             });
             download.failed.connect ((error) => {
                 loading = false;


### PR DESCRIPTION
![screenshot from 2018-11-01 16-07-25](https://user-images.githubusercontent.com/1204189/47860187-438cf180-ddf0-11e8-9733-c8fed7e1419c.png)

After looking at the downloads popover the style class is removed and no longer visually demanding attention.

I thought the "needs-attention" style class might be appropriate here but it doesn't seem to work since it's only an animation, so I opted for the "suggested action" instead.