### PR TITLE
Replace leftover libsoup-gnome pkg-config check with libsoup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ find_package(PkgConfig)
 pkg_check_modules(DEPS REQUIRED
                   sqlite3>=3.6.19
                   gio-2.0>=2.48.0
-                  libsoup-gnome-2.4>=2.48.0
+                  libsoup-2.4>=2.48.0
                   )
 set(PKGS sqlite3 gio-2.0 libsoup-2.4)
 


### PR DESCRIPTION
Update the libsoup-gnome pkg-config check to use libsoup instead.
All of libsoup-gnome has been deprecated in 2.41.3, and packages ought
to depend purely on libsoup these days.  Looking at the 'PKGS' below,
I think the pkg-config check was only leftover.

Midori builds just fine after the replacement.  It is necessary since
Gentoo no longer ships libsoup-gnome.