### PR TITLE
Hide downloads and clear model when clicking Clear

### DIFF
--- a/core/download-button.vala
+++ b/core/download-button.vala
@@ -19,6 +19,8 @@ namespace Midori {
         [GtkChild]
         public Gtk.Popover popover;
         [GtkChild]
+        public Gtk.Button clear;
+        [GtkChild]
         public Gtk.ListBox listbox;
 
         string cache = File.new_for_path (Path.build_filename (
@@ -28,6 +30,10 @@ namespace Midori {
         construct {
             listbox.bind_model (model, create_row);
             popover.relative_to = this;
+            clear.clicked.connect (() => {
+                hide ();
+                model.remove_all ();
+            });
         }
 
         internal WebKit.WebContext web_context { set {

--- a/ui/download-button.ui
+++ b/ui/download-button.ui
@@ -22,7 +22,7 @@
               </object>
             </child>
             <child>
-              <object class="GtkButton">
+              <object class="GtkButton" id="clear">
                 <property name="focus-on-click">no</property>
                 <property name="relief">half</property>
                 <property name="label" translatable="yes" context="downloads">_Clear</property>


### PR DESCRIPTION
The "Clear" button should clear all downloads, and consequently hide the downloads button.