### PR TITLE
Require CMake 3.2 for the "continue" command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,6 @@
 # Copyright (C) 2013-2018 Christian Dywan <christian@twotoasts.de>
 
-cmake_minimum_required(VERSION 3.0)
-cmake_policy(VERSION 3.0)
+cmake_minimum_required(VERSION 3.2)
 
 # dh_translations detects this if there's no variable used
 set (GETTEXT_PACKAGE "midori")


### PR DESCRIPTION
The actual CMake required is version 3.2. This should've been increased when starting to use the `continue` command.

Note: The policy command is redundant if it matches the required version.