### PR TITLE
Fix handling LINGUAS with unsupported languages

### DIFF
--- a/po/CMakeLists.txt
+++ b/po/CMakeLists.txt
@@ -2,13 +2,27 @@
 
 include(FindGettext)
 if (GETTEXT_FOUND)
-    set(LANGUAGES $ENV{LINGUAS})
-    if (NOT LANGUAGES)
-        file(GLOB POTFILES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "*.po")
-        string(REPLACE ".po" " " LANGUAGES ${POTFILES})
-    endif ()
+    file(GLOB POTFILES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "*.po")
+    string(REPLACE ".po" ";" ALL_LANGUAGES ${POTFILES})
+
+    # if LINGUAS is set, we need to filter its values to languages
+    # actually supported
+    # NB: LINGUAS="" is distinct from unset, and means 'install no l10n'
+    if(DEFINED ENV{LINGUAS})
+        set(LINGUAS $ENV{LINGUAS})
+        string(REPLACE " " ";" LINGUAS "${LINGUAS}")
+        set(LANGUAGES)
+        foreach(LANG ${LINGUAS})
+            list(FIND ALL_LANGUAGES ${LANG} LANG_IDX)
+            if(NOT LANG_IDX EQUAL -1)
+                list(APPEND LANGUAGES ${LANG})
+            endif()
+        endforeach()
+    else()
+        set(LANGUAGES ${ALL_LANGUAGES})
+    endif()
+
     message(STATUS "gettext found: ${LANGUAGES}")
-    string(REPLACE " " ";" LANGUAGES ${LANGUAGES})
     if ("${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}.${CMAKE_PATCH_VERSION}" VERSION_LESS "2.8.8")
         GETTEXT_CREATE_TRANSLATIONS("${CMAKE_CURRENT_SOURCE_DIR}/${CMAKE_PROJECT_NAME}.pot" ALL ${POTFILES})
     else()


### PR DESCRIPTION
Fix the LINGUAS parsing code to strip unsupported languages.  Otherwise,
the build will fail when user's LINGUAS contains a value that is not
supported by midori (e.g. 'pl').  While at it, also make sure that
empty LINGUAS is handled distinctly from unset.