### PR TITLE
Show tab popover relative to urlbar with no opacity changes

### DIFF
--- a/core/browser.vala
+++ b/core/browser.vala
@@ -521,6 +521,7 @@ namespace Midori {
         }
 
         public new void add (Tab tab) {
+            tab.popover.relative_to = navigationbar.urlbar;
             tab.create.connect ((action) => {
                 var new_tab = new Tab (tab, web_context);
                 new_tab.hide ();

--- a/ui/tab.ui
+++ b/ui/tab.ui
@@ -2,6 +2,7 @@
   <object class="GtkPopover" id="popover">
     <property name="modal">yes</property>
     <property name="position">bottom</property>
+    <property name="relative-to">MidoriTab</property>
     <child>
       <object class="GtkBox">
         <property name="orientation">vertical</property>


### PR DESCRIPTION

![screenshot from 2018-11-05 15-13-30](https://user-images.githubusercontent.com/1204189/48003051-9d9df780-e10d-11e8-904f-26bd02312b36.png)
Popovers really don't work well unless they're given an explicit
position. So for a tab that may be the tab itself or better yet
the urlbar of the containing browser.

With some themes the entire tabs goes blank due to opacity
changes, and even if it doesn't the translucency may leave
the user unclear as to what's happening. So let's not do this.

Fixes: #163

Also use the popover to re-implement permission requests.

Fixes: #158