### PR TITLE
Create independent tabs to allow for more processes

### DIFF
--- a/core/app.vala
+++ b/core/app.vala
@@ -104,6 +104,7 @@ namespace Midori {
                 Environment.get_user_cache_dir (), Environment.get_prgname ());
             string icons = Path.build_path (Path.DIR_SEPARATOR_S, cache, "icondatabase");
             context.set_favicon_database_directory (icons);
+            context.set_process_model (WebKit.ProcessModel.MULTIPLE_SECONDARY_PROCESSES);
 
             // Try and load web extensions from build folder
             var web_path = exec_path.get_parent ().get_child ("web");

--- a/core/browser.vala
+++ b/core/browser.vala
@@ -331,7 +331,7 @@ namespace Midori {
         }
 
         void tab_new_activated () {
-            var tab = new Tab (tab, web_context);
+            var tab = new Tab (null, web_context);
             add (tab);
             tabs.visible_child = tab;
         }
@@ -348,7 +348,7 @@ namespace Midori {
             uint index = trash.get_n_items ();
             if (index > 0) {
                 var item = trash.get_object (index - 1) as DatabaseItem;
-                add (new Tab (tab, web_context, item.uri, item.title));
+                add (new Tab (null, web_context, item.uri, item.title));
                 trash.remove (index - 1);
             }
         }

--- a/core/network-check.vala
+++ b/core/network-check.vala
@@ -28,7 +28,7 @@ namespace Midori {
 
         void login_clicked () {
             var browser = ((Browser)get_toplevel ());
-            browser.add (new Tab (browser.tab, browser.web_context, "http://example.com"));
+            browser.add (new Tab (null, browser.web_context, "http://example.com"));
         }
     }
 }

--- a/core/tab.vala
+++ b/core/tab.vala
@@ -273,7 +273,7 @@ namespace Midori {
                 var action = new Gtk.Action ("text-search", _("Search for %s").printf (label), null, null);
                 action.activate.connect (() => {
                     var settings = CoreSettings.get_default ();
-                    var tab = new Tab (this, web_context, settings.uri_for_search (text));
+                    var tab = new Tab (null, web_context, settings.uri_for_search (text));
                     ((Browser)get_toplevel ()).add (tab);
                 });
                 menu.append (new WebKit.ContextMenuItem (action));

--- a/core/urlbar.vala
+++ b/core/urlbar.vala
@@ -138,7 +138,7 @@ namespace Midori {
                             Application.get_default ().activate_action ("win-new", text);
                         } else {
                             var browser = ((Browser)get_toplevel ());
-                            browser.add (new Tab (browser.tab, browser.web_context, text));
+                            browser.add (new Tab (null, browser.web_context, text));
                         }
                     } else {
                         listbox.activate_cursor_row ();

--- a/extensions/session.vala
+++ b/extensions/session.vala
@@ -213,7 +213,7 @@ namespace Tabby {
                     var app = (Midori.App)default_browser.get_application ();
                     browser = browser_for_session (app, id);
                 }
-                var tab = new Midori.Tab (browser.tab, browser.web_context,
+                var tab = new Midori.Tab (null, browser.web_context,
                                           item.uri, item.title);
                 connect_tab (tab, item);
                 browser.add (tab);


### PR DESCRIPTION
The related tab does two things:
1. Connect the scripting contexts (eg. opening a window/ tab)
2. Re-use the process between those tabs

By not setting it more processes will be used.