### PR TITLE
Always set key regardless of location guess

### DIFF
--- a/core/suggestion-row.vala
+++ b/core/suggestion-row.vala
@@ -42,7 +42,7 @@ namespace Midori {
                     }
                 });
                 notify["key"].connect ((pspec) => {
-                    if (key != null) {
+                    if (location == null) {
                         var suggestion = (SuggestionItem)item;
                         item.uri = CoreSettings.get_default ().uri_for_search (key, suggestion.search);
                         icon.icon_name = "edit-find-symbolic";

--- a/core/urlbar.vala
+++ b/core/urlbar.vala
@@ -165,18 +165,14 @@ namespace Midori {
 
         void update_key (string text) {
             location = magic_uri (text);
-            if (location == null) {
-                try {
-                    key = text;
-                    regex = new Regex ("(%s)".printf (Regex.escape_string (key)),
-                                       RegexCompileFlags.CASELESS);
-                } catch (RegexError error) {
-                    debug ("Failed to create regex: %s", error.message);
-                }
-            } else {
+            try {
+                key = text;
+                regex = new Regex ("(%s)".printf (Regex.escape_string (key)),
+                                   RegexCompileFlags.CASELESS);
+            } catch (RegexError error) {
                 regex = null;
+                debug ("Failed to create regex: %s", error.message);
             }
-
         }
 
         string? magic_uri (string text) {


### PR DESCRIPTION
`location` is set based on the guessing the difference between search terms and a domain or local path. The mistake here was only setting `key` if it's unset.

Fixes: #162 