### PR TITLE
Hide page and browser actions when window is small

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ You'll want to **unit test** the code if you're testing a new version or contrib
 * Download button lists on-going and finished downloads
 * `javascript:alert("test")`, `javascript:confirm("test")` and `javascript:input("test")` work
 * Websites can (un)toggle fullscreen mode
+* Shrinking the window moves browser and page actions into the respective menus
 
 # Release process
 

--- a/core/navigationbar.vala
+++ b/core/navigationbar.vala
@@ -13,6 +13,8 @@ namespace Midori {
     [GtkTemplate (ui = "/ui/navigationbar.ui")]
     public class Navigationbar : Gtk.ActionBar {
         [GtkChild]
+        public Gtk.Box actionbox;
+        [GtkChild]
         public Gtk.Button go_back;
         [GtkChild]
         public Gtk.Button go_forward;

--- a/data/gtk3.css
+++ b/data/gtk3.css
@@ -96,6 +96,9 @@ statusbar button {
   padding: 0 4px;
 }
 
+.urlbar {
+  margin: 0 4px;
+}
 /* Emphasize security indicator */
 .urlbar image.left {
   color: @theme_selected_bg_color;

--- a/ui/browser.ui
+++ b/ui/browser.ui
@@ -58,24 +58,6 @@
               </object>
             </child>
             <child>
-              <object class="GtkButton" id="toggle_fullscreen">
-                <property name="focus-on-click">no</property>
-                <property name="valign">center</property>
-                <property name="action-name">win.fullscreen</property>
-                <property name="tooltip-text" translatable="yes">Toggle fullscreen view</property>
-                <property name="visible">yes</property>
-                <child>
-                  <object class="GtkImage">
-                    <property name="icon-name">view-fullscreen-symbolic</property>
-                    <property name="visible">yes</property>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="pack-type">end</property>
-              </packing>
-            </child>
-            <child>
               <object class="GtkMenuButton" id="app_menu">
                 <property name="focus-on-click">no</property>
                 <property name="valign">center</property>
@@ -87,41 +69,59 @@
               </packing>
             </child>
             <child>
-              <object class="MidoriDownloadButton" id="downloads">
-                <property name="valign">center</property>
-              </object>
-              <packing>
-                <property name="pack-type">end</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkToggleButton" id="panel_toggle">
-                <property name="focus-on-click">no</property>
-                <property name="valign">center</property>
-                <property name="action-name">win.panel</property>
-                <property name="tooltip-text" translatable="yes">Sidepanel</property>
+              <object class="GtkBox" id="actionbox">
+                <property name="orientation">horizontal</property>
+                <property name="visible">yes</property>
+                <style>
+                  <class name="linked"/>
+                </style>
                 <child>
-                  <object class="GtkImage">
-                    <property name="icon-name">view-grid-symbolic</property>
+                  <object class="GtkButton" id="tab_new">
+                    <property name="focus-on-click">no</property>
+                    <property name="valign">center</property>
+                    <property name="action-name">win.tab-new</property>
+                    <property name="tooltip-text" translatable="yes">Open a new tab</property>
                     <property name="visible">yes</property>
+                    <child>
+                      <object class="GtkImage">
+                        <property name="icon-name">tab-new-symbolic</property>
+                        <property name="visible">yes</property>
+                      </object>
+                    </child>
                   </object>
                 </child>
-              </object>
-              <packing>
-                <property name="pack-type">start</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="tab_new">
-                <property name="focus-on-click">no</property>
-                <property name="valign">center</property>
-                <property name="action-name">win.tab-new</property>
-                <property name="tooltip-text" translatable="yes">Open a new tab</property>
-                <property name="visible">yes</property>
                 <child>
-                  <object class="GtkImage">
-                    <property name="icon-name">tab-new-symbolic</property>
+                  <object class="GtkToggleButton" id="panel_toggle">
+                    <property name="focus-on-click">no</property>
+                    <property name="valign">center</property>
+                    <property name="action-name">win.panel</property>
+                    <property name="tooltip-text" translatable="yes">Sidepanel</property>
+                    <child>
+                      <object class="GtkImage">
+                        <property name="icon-name">view-grid-symbolic</property>
+                        <property name="visible">yes</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="MidoriDownloadButton" id="downloads">
+                    <property name="valign">center</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkButton" id="toggle_fullscreen">
+                    <property name="focus-on-click">no</property>
+                    <property name="valign">center</property>
+                    <property name="action-name">win.fullscreen</property>
+                    <property name="tooltip-text" translatable="yes">Toggle fullscreen view</property>
                     <property name="visible">yes</property>
+                    <child>
+                      <object class="GtkImage">
+                        <property name="icon-name">view-fullscreen-symbolic</property>
+                        <property name="visible">yes</property>
+                      </object>
+                    </child>
                   </object>
                 </child>
               </object>
@@ -133,9 +133,6 @@
               <class name="tabbar"/>
             </style>
           </object>
-          <packing>
-            <property name="shrink">no</property>
-          </packing>
         </child>
       </object>
     </child>
@@ -216,6 +213,9 @@
                   </object>
                 </child>
               </object>
+              <packing>
+                <property name="shrink">no</property>
+              </packing>
             </child>
           </object>
         </child>

--- a/ui/download-button.ui
+++ b/ui/download-button.ui
@@ -16,8 +16,6 @@
             <child>
               <object class="GtkLabel">
                 <property name="label" translatable="yes">Downloads</property>
-                <property name="hexpand">yes</property>
-                <property name="width-chars">33</property>
                 <property name="visible">yes</property>
               </object>
             </child>

--- a/ui/download-row.ui
+++ b/ui/download-row.ui
@@ -32,7 +32,7 @@
                 <property name="xalign">0.0</property>
                 <property name="hexpand">yes</property>
                 <!-- As per docs, when ellipsized and expanded max width is the minimum -->
-                <property name="max-width-chars">1</property>
+                <property name="max-width-chars">20</property>
                 <property name="visible">yes</property>
               </object>
             </child>

--- a/ui/menus.ui
+++ b/ui/menus.ui
@@ -1,4 +1,33 @@
 <interface>
+  <menu id="app-menu-small">
+    <section>
+      <attribute name="display-hint">horizontal-buttons</attribute>
+      <item>
+        <attribute name="action">win.tab-new</attribute>
+        <attribute name="hidden-when">action-disabled</attribute>
+        <attribute name="label" translatable="yes">Open a new tab</attribute>
+        <attribute name="verb-icon">tab-new-symbolic</attribute>
+      </item>
+      <item>
+        <attribute name="action">win.panel</attribute>
+        <attribute name="hidden-when">action-disabled</attribute>
+        <attribute name="label" translatable="yes">Sidepanel</attribute>
+        <attribute name="verb-icon">view-grid-symbolic</attribute>
+      </item>
+      <item>
+        <attribute name="action">win.show-downloads</attribute>
+        <attribute name="hidden-when">action-disabled</attribute>
+        <attribute name="label" translatable="yes">View downloaded files</attribute>
+        <attribute name="verb-icon">folder-download-symbolic</attribute>
+      </item>
+      <item>
+        <attribute name="action">win.fullscreen</attribute>
+        <attribute name="hidden-when">action-disabled</attribute>
+        <attribute name="label" translatable="yes">Toggle fullscreen view</attribute>
+        <attribute name="verb-icon">view-fullscreen-symbolic</attribute>
+      </item>
+    </section>
+  </menu>
   <menu id="app-menu">
     <section>
       <item>
@@ -40,6 +69,39 @@
         <attribute name="action">app.quit</attribute>
         <attribute name="label" translatable="yes">Close a_ll Windows</attribute>
         <attribute name="accel">&lt;Primary&gt;q</attribute>
+      </item>
+    </section>
+  </menu>
+  <menu id="page-menu-small">
+    <section>
+      <attribute name="display-hint">horizontal-buttons</attribute>
+      <item>
+        <attribute name="action">win.go-back</attribute>
+        <attribute name="label" translatable="yes">Go back to the previous page</attribute>
+        <attribute name="verb-icon">go-previous-symbolic</attribute>
+      </item>
+      <item>
+        <attribute name="action">win.go-forward</attribute>
+        <attribute name="label" translatable="yes">Go forward to the next page</attribute>
+        <attribute name="verb-icon">go-next-symbolic</attribute>
+      </item>
+      <item>
+        <attribute name="action">win.tab-reload</attribute>
+        <attribute name="hidden-when">action-disabled</attribute>
+        <attribute name="label" translatable="yes">Reload the current page</attribute>
+        <attribute name="verb-icon">view-refresh-symbolic</attribute>
+      </item>
+      <item>
+        <attribute name="action">win.tab-stop-loading</attribute>
+        <attribute name="hidden-when">action-disabled</attribute>
+        <attribute name="label" translatable="yes">Stop loading the current page</attribute>
+        <attribute name="verb-icon">process-stop-symbolic</attribute>
+      </item>
+      <item>
+        <attribute name="action">win.homepage</attribute>
+        <attribute name="hidden-when">action-disabled</attribute>
+        <attribute name="label" translatable="yes">Go to your homepage</attribute>
+        <attribute name="verb-icon">user-home-symbolic</attribute>
       </item>
     </section>
   </menu>

--- a/ui/navigationbar.ui
+++ b/ui/navigationbar.ui
@@ -1,26 +1,26 @@
 <interface>
   <template class="MidoriNavigationbar" parent="GtkActionBar">
-   <child>
-    <object class="GtkBox">
-      <property name="orientation">horizontal</property>
-      <property name="visible">yes</property>
-      <style>
-        <class name="linked"/>
-      </style>
-      <child>
-        <object class="GtkButton" id="go_back">
-          <property name="focus-on-click">no</property>
-          <property name="action-name">win.go-back</property>
-          <property name="tooltip-text" translatable="yes">Go back to the previous page</property>
-          <property name="visible">yes</property>
-          <child>
-            <object class="GtkImage">
-              <property name="icon-name">go-previous-symbolic</property>
-              <property name="visible">yes</property>
-            </object>
-          </child>
-        </object>
-      </child>
+    <child>
+      <object class="GtkBox" id="actionbox">
+        <property name="orientation">horizontal</property>
+        <property name="visible">yes</property>
+        <style>
+          <class name="linked"/>
+        </style>
+        <child>
+          <object class="GtkButton" id="go_back">
+            <property name="focus-on-click">no</property>
+            <property name="action-name">win.go-back</property>
+            <property name="tooltip-text" translatable="yes">Go back to the previous page</property>
+            <property name="visible">yes</property>
+            <child>
+              <object class="GtkImage">
+                <property name="icon-name">go-previous-symbolic</property>
+                <property name="visible">yes</property>
+              </object>
+            </child>
+          </object>
+        </child>
         <child>
           <object class="GtkButton" id="go_forward">
             <property name="focus-on-click">no</property>
@@ -35,8 +35,6 @@
             </child>
           </object>
         </child>
-      </object>
-    </child>
     <child>
       <object class="GtkButton" id="reload">
         <property name="focus-on-click">no</property>
@@ -78,12 +76,12 @@
         </child>
       </object>
     </child>
+      </object>
+    </child>
     <child type="center">
       <object class="MidoriUrlbar" id="urlbar">
         <!-- expand has no effect, int.MAX doesn't work -->
         <property name="max-width-chars">300</property>
-        <property name="margin-left">16</property>
-        <property name="margin-right">16</property>
         <property name="visible">yes</property>
       </object>
     </child>


### PR DESCRIPTION
- At a width of less than 500 the browser window is considered small
and the left-hand page action buttons as well as the right-hand
window actions are hidden and added to the respective menus.
- Downloads show relative to the app menu if there's no visible button.
- The shrink constraint is moved from the navigationbar to the tab itself.
- Urlbar margins are moved to CSS.
- Effective minimum width becomes 269px with Adwaita w/o title buttons.

To make this work the relevant actions need to be enabled and
disabled when they're available and unavailable respectively.

![screenshot from 2018-11-19 08-34-09](https://user-images.githubusercontent.com/1204189/48690203-3cc6f280-ebd6-11e8-8b0d-148ee912dc64.png)
![screenshot from 2018-11-19 08-36-05](https://user-images.githubusercontent.com/1204189/48690202-3c2e5c00-ebd6-11e8-8813-22a8a6429515.png)