### PR TITLE
Don't add bookmarks UX when in app mode

### DIFF
--- a/extensions/bookmarks.vala
+++ b/extensions/bookmarks.vala
@@ -193,6 +193,11 @@ namespace Bookmarks {
         public Midori.Browser browser { owned get; set; }
 
         public void activate () {
+            // No bookmarks in app mode
+            if (browser.is_locked) {
+                return;
+            }
+
             browser.add_button (new Button (browser));
         }
     }


### PR DESCRIPTION
It makes little sense to bookmark a website in app mode when there's only one website to be shown.