### PR TITLE
(Re)store last window width and height

### DIFF
--- a/core/browser.vala
+++ b/core/browser.vala
@@ -320,6 +320,11 @@ namespace Midori {
             if (web_context.is_ephemeral ()) {
                 get_style_context ().add_class ("incognito");
             }
+
+            if (settings.last_window_width > 0 && settings.last_window_height > 0) {
+                default_width = settings.last_window_width;
+                default_height = settings.last_window_height;
+            }
         }
 
         void update_decoration_layout () {
@@ -339,6 +344,14 @@ namespace Midori {
             int width;
             get_size (out width, null);
             is_small = width < 500;
+
+            if (!(get_style_context ().has_class ("tiled") || is_maximized || is_fullscreen)) {
+                int height;
+                get_size (null, out height);
+                var settings = CoreSettings.get_default ();
+                settings.last_window_width = width;
+                settings.last_window_height = height;
+            }
 
             return result;
         }

--- a/core/settings.vala
+++ b/core/settings.vala
@@ -42,6 +42,17 @@ namespace Midori {
             set_boolean ("extensions", "lib%s.so".printf (plugin), enabled);
         }
 
+        public int last_window_width { get {
+            return get_string ("settings", "last-window-width", "710").to_int ();
+        } set {
+            set_string ("settings", "last-window-width", value.to_string ());
+        } }
+        public int last_window_height { get {
+            return get_string ("settings", "last-window-height", "530").to_int ();
+        } set {
+            set_string ("settings", "last-window-height", value.to_string ());
+        } }
+
         // Note: Speed Dial is saved as Blank Page for compatibility reasons
         public StartupType load_on_startup { get {
             var startup = get_string ("settings", "load-on-startup", "MIDORI_STARTUP_LAST_OPEN_PAGES");

--- a/ui/browser.ui
+++ b/ui/browser.ui
@@ -15,8 +15,6 @@
     </widgets>
   </object>
   <template class="MidoriBrowser" parent="GtkApplicationWindow">
-    <property name="default-width">710</property>
-    <property name="default-height">530</property>
     <child type="titlebar">
       <object class="GtkPaned">
         <property name="visible">yes</property>


### PR DESCRIPTION
- Save the size of a non-tiled/ -maximized/ -fullscreen browser
- Use the last known dimensions as the default size