### PR TITLE
Don't consume the tab's focus in event

### DIFF
--- a/core/tab.vala
+++ b/core/tab.vala
@@ -109,7 +109,7 @@ namespace Midori {
             if (display_uri != uri) {
                 load_uri (display_uri);
             }
-            return true;
+            return base.focus_in_event (event);
         }
 
         void update_progress (ParamSpec pspec) {


### PR DESCRIPTION
WebKit needs to handle focus events to update the
visibility of the cursor.

Fixes: #181