### PR TITLE
Carry error state and tls certificate in tab

### DIFF
--- a/core/urlbar.vala
+++ b/core/urlbar.vala
@@ -284,9 +284,7 @@ namespace Midori {
         }
 
         void icon_pressed (Gtk.EntryIconPosition position, Gdk.Event event) {
-            TlsCertificate tls;
-            TlsCertificateFlags flags;
-            ((Browser)get_toplevel ()).tab.get_tls_info (out tls, out flags);
+            var tls = ((Browser)get_toplevel ()).tab.tls;
             var certificate = tls != null ? new Gcr.SimpleCertificate (tls.certificate.data) : null;
             if (details == null) {
                 var icon_area = get_icon_area (position);


### PR DESCRIPTION
In case of errors the WebView won't save the certificate
so it needs to be saved in the error handler.

Fixes: #74 #188 

Note that this us a prerequisite to handling #182.