### PR TITLE
Release Midori 7.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ add_definitions("-DGETTEXT_PACKAGE=\"${GETTEXT_PACKAGE}\"")
 project(${GETTEXT_PACKAGE} C)
 set(PROJECT_BUGS https://github.com/midori-browser/core/issues)
 set(PROJECT_WEBSITE https://www.midori-browser.org)
-set(CORE_VERSION 6.0)
+set(CORE_VERSION 7.0)
 
 execute_process(COMMAND "git" "describe" "--tags"
                 OUTPUT_VARIABLE REVISION

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,13 @@
+v7.0
+ Fixed YouTube rendering issue due to custom user agent
+ Fixed invisible cursor in text fields
+ Restored behavior of " " and "." in urlbar completion
+ Download/ web notifications for background window/ tab
+ Highlight in toolbar for finished downloads
+ Re-introduced proxy server UX
+ Multiple processes for indivdual tabs
+ Adaptive toolbar layout for smaller screens
+
 v6.0
  Revamped Vala-only core based on GTK+3 and WebKit2
  App based on Gtk.Application, supporting global/ window app menu

--- a/README.md
+++ b/README.md
@@ -101,13 +101,13 @@ You'll want to **unit test** the code if you're testing a new version or contrib
 
 # Release process
 
-Update `CORE_VERSION` in `CMakeLists.txt` to `6.0`.
+Update `CORE_VERSION` in `CMakeLists.txt` to `7.0`.
 Add a section to `ChangeLog`.
 
-    git commit -p -v -m "Release Midori 6.0"
-    git checkout -B release-6.0
+    git commit -p -v -m "Release Midori 7.0"
+    git checkout -B release-7.0
     git push origin HEAD
-    git archive -o midori-v6.0.tar.gz -9 HEAD
+    git archive --prefix=midori-v7.0/ -o midori-v7.0.tar.gz -9 HEAD
 
 Propose a PR for the release.
 Publish the release on https://github.com/midori-browser/core/releases


### PR DESCRIPTION
- Bump to 7.0
- Updated `ChangeLog`
- Updated release steps in `README.md` to include tarball prefix

Fixes: #150