### PR TITLE
Move appdata file to new location

### DIFF
--- a/cmake/FindIntltool.cmake
+++ b/cmake/FindIntltool.cmake
@@ -25,7 +25,7 @@ if (INTLTOOL_MERGE_EXECUTABLE)
             DEPENDS ${desktop_id}.appdata.xml.in
         )
         install (FILES "${CMAKE_CURRENT_BINARY_DIR}/${desktop_id}.appdata.xml"
-                 DESTINATION "${CMAKE_INSTALL_PREFIX}/share/appdata")
+                 DESTINATION "${CMAKE_INSTALL_PREFIX}/share/metainfo")
     endmacro (INTLTOOL_MERGE_APPDATA desktop_id po_dir)
 else ()
     message(FATAL_ERROR "intltool-merge not found")


### PR DESCRIPTION
According to lintian on Debian, the old appdata location of
/usr/share/appdata is deprecated and these files should instead
be placed in the new location of /usr/share/metainfo.

See here for more information: https://lintian.debian.org/tags/appstream-metadata-in-legacy-location.html