### PR TITLE
android: Add Clear Private Data to app menu

### DIFF
--- a/app/src/main/java/org/midori_browser/midori/BrowserActivity.kt
+++ b/app/src/main/java/org/midori_browser/midori/BrowserActivity.kt
@@ -14,10 +14,13 @@ import android.view.Menu
 import android.view.MenuItem
 import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputMethodManager
+import android.webkit.CookieManager
 import android.webkit.WebSettings
+import android.webkit.WebStorage
 import android.widget.AdapterView
 import android.widget.ArrayAdapter
 import kotlinx.android.synthetic.main.activity_browser.*
+import java.util.ResourceBundle.clearCache
 
 class BrowserActivity : AppCompatActivity() {
 
@@ -117,6 +120,13 @@ class BrowserActivity : AppCompatActivity() {
                 intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
             }
             startActivity(Intent.createChooser(share, getString(R.string.actionShare)))
+            true
+        }
+        R.id.actionClearPrivateData -> {
+            @Suppress("DEPRECATION")
+            CookieManager.getInstance().removeAllCookie()
+            WebStorage.getInstance().deleteAllData()
+            webView.clearCache(true)
             true
         }
         else -> {

--- a/app/src/main/res/drawable/ic_clear_private_data_24dp.xml
+++ b/app/src/main/res/drawable/ic_clear_private_data_24dp.xml
@@ -1,0 +1,8 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path android:fillColor="#eee"
+          android:pathData="M6,19c0,1.1 0.9,2 2,2h8c1.1,0 2,-0.9 2,-2L18,7L6,7v12zM8.46,11.88l1.41,-1.41L12,12.59l2.12,-2.12 1.41,1.41L13.41,14l2.12,2.12 -1.41,1.41L12,15.41l-2.12,2.12 -1.41,-1.41L10.59,14l-2.13,-2.12zM15.5,4l-1,-1h-5l-1,1L5,4v2h14L19,4z"/>
+</vector>

--- a/app/src/main/res/menu/app_menu.xml
+++ b/app/src/main/res/menu/app_menu.xml
@@ -5,4 +5,9 @@
           android:title="@string/actionShare"
           android:icon="@drawable/ic_share_24dp"
           app:showAsAction="ifRoom"/>
+
+    <item android:id="@+id/actionClearPrivateData"
+          android:title="@string/actionClearPrivateData"
+          android:icon="@drawable/ic_clear_private_data_24dp"
+          app:showAsAction="ifRoom"/>
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,6 +4,7 @@
     <string name="userAgentVersion">Midori/6</string>
 
     <string name="actionShare">Share</string>
+    <string name="actionClearPrivateData">Clear Private Data</string>
 
     <string name="hintSearchOrEnterAddress">Search or enter an address</string>
 </resources>


### PR DESCRIPTION
Add a `Clear Private Data` menu item to the app menu.

All data is erased unconditionally. The feature is currently not configurable.