### PR TITLE
android: add request desktop site toggle

### DIFF
--- a/app/src/main/java/org/midori_browser/midori/BrowserActivity.kt
+++ b/app/src/main/java/org/midori_browser/midori/BrowserActivity.kt
@@ -31,7 +31,7 @@ class BrowserActivity : AppCompatActivity() {
 
         val webSettings = webView.settings
         webSettings.javaScriptEnabled = true
-        webSettings.userAgentString += " " + getString(R.string.userAgentVersion)
+        requestDesktopSite(false)
         webSettings.databaseEnabled = true
         webSettings.setAppCacheEnabled(true)
         webSettings.domStorageEnabled = true
@@ -106,6 +106,20 @@ class BrowserActivity : AppCompatActivity() {
     }
 
     val completion = listOf("www.midori-browser.org", "example.com", "duckduckgo.com")
+    fun requestDesktopSite(desktopSite: Boolean) {
+        webView.settings.apply {
+            userAgentString = null // Reset to default
+            userAgentString = userAgentString + " " + getString(R.string.userAgentVersion)
+            if (desktopSite) {
+                // Websites look for "Android" and "Mobile" keywords to decide what's not desktop
+                val mobileOS = userAgentString.substring(userAgentString.indexOf("("), userAgentString.indexOf(")") + 1)
+                userAgentString = userAgentString.replace(mobileOS, "(X11; Linux x86_64)").replace(" Mobile", "")
+            }
+            useWideViewPort = desktopSite
+            loadWithOverviewMode = desktopSite
+        }
+    }
+
 
     override fun onCreateOptionsMenu(menu: Menu?): Boolean {
         menuInflater.inflate(R.menu.app_menu, menu)
@@ -127,6 +141,12 @@ class BrowserActivity : AppCompatActivity() {
             CookieManager.getInstance().removeAllCookie()
             WebStorage.getInstance().deleteAllData()
             webView.clearCache(true)
+            true
+        }
+        R.id.actionRequestDesktopSite -> {
+            item.isChecked = !item.isChecked
+            requestDesktopSite(item.isChecked)
+            webView.reload()
             true
         }
         else -> {

--- a/app/src/main/res/menu/app_menu.xml
+++ b/app/src/main/res/menu/app_menu.xml
@@ -10,4 +10,7 @@
           android:title="@string/actionClearPrivateData"
           android:icon="@drawable/ic_clear_private_data_24dp"
           app:showAsAction="ifRoom"/>
+    <item android:id="@+id/actionRequestDesktopSite"
+          android:title="@string/actionRequestDesktopSite"
+          android:checkable="true"/>
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,6 +5,7 @@
 
     <string name="actionShare">Share</string>
     <string name="actionClearPrivateData">Clear Private Data</string>
+    <string name="actionRequestDesktopSite">Request Desktop site</string>
 
     <string name="hintSearchOrEnterAddress">Search or enter an address</string>
 </resources>


### PR DESCRIPTION
Provide a menu item

- to change the user agent platform from Android to X11 Linux
- drop the 'Mobile' keyword from the user agent
- change view port to desktop behavior