### PR TITLE
Don't disable the fullscreen action

### DIFF
--- a/core/browser.vala
+++ b/core/browser.vala
@@ -185,9 +185,6 @@ namespace Midori {
             var fullscreen = new SimpleAction ("fullscreen", null);
             fullscreen.activate.connect (fullscreen_activated);
             add_action (fullscreen);
-            navigationbar.notify["visible"].connect (() => {
-                fullscreen.set_enabled (navigationbar.visible);
-            });
             // Action for panel toggling
             action = new SimpleAction.stateful ("panel", null, false);
             action.set_enabled (false);


### PR DESCRIPTION
Although the toggle may be hidden, the action needs to be enabled
to be activated programmatically.

Fixes: #210