### PR TITLE
Disable focus on Urlbar when activating tab in Non-Fullscreen mode.

### DIFF
--- a/core/browser.vala
+++ b/core/browser.vala
@@ -437,7 +437,8 @@ namespace Midori {
         void goto_activated () {
             if (!tab.pinned) {
                 navigationbar.show ();
-                navigationbar.urlbar.grab_focus ();
+                if (is_fullscreen)
+                    navigationbar.urlbar.grab_focus ();
             }
         }
 


### PR DESCRIPTION
I find annoying that every time you change a tab the url bar gets selected automatically.

I added a check, that it only selects (set the focus) the urlbar in case the Fullscreen mode is active.

I guess that behavior is intended only for fullscreen mode (maybe kiosk mode or something) so I added a check if that's the case.