### PR TITLE
Fix Adblock not working

### DIFF
--- a/extensions/adblock/subscription.vala
+++ b/extensions/adblock/subscription.vala
@@ -355,7 +355,21 @@ namespace Adblock {
                 debug ("%s for %s (%s)", directive.to_string (), request_uri, page_uri);
                 return directive;
             }
-            return null;
+
+            try {
+                //The uri is either Allowed(whitelist), Blocked(pattern), or neither
+                directive = whitelist.match (request_uri, page_uri);
+                if (directive == null) {
+                    directive = pattern.match (request_uri, page_uri);
+                }
+            } catch (Error error) {
+                critical ("Error matching %s %s: %s", request_uri, uri, error.message);
+            }
+
+            if (directive != null)
+                cache.insert (request_uri, directive);
+
+            return directive;
         }
     }
 }


### PR DESCRIPTION
The uris were never checked against the filter list of blocked uris (pattern) nor the whitelist.

This should fix the adblock with a caveat.

I was testing it, and for some reason works only half of the time. I know it should not work with all the ads, for start the easylist coverage is relatively small plus I'm in a spanish speaking country and I might be outside of the coverage.

Another issue, the subscription of seems to be not working properly.
For example add EasyList for Spanish, and for some reason the file is not parsed.

The files are downloaded and stored locally in ~/.cache/midori/adblock/
No matter how many lists you are subscribed to, I only see 2 the defaults one.

For the moment, I think my patch only fix #253 partially. And I don't fully understand how adblock works.