### PR TITLE
Only load web extensions which are enabled

### DIFF
--- a/core/app.vala
+++ b/core/app.vala
@@ -167,10 +167,10 @@ namespace Midori {
             var plugins = Plugins.get_default (builtin_path.get_path ());
             // Save/ load state of plugins
             plugins.load_plugin.connect ((info) => {
-                settings.set_plugin_enabled (info.get_module_name (), true);
+                settings.set_plugin_enabled ("lib%s.so".printf (info.get_module_name ()), true);
             });
             plugins.unload_plugin.connect ((info) => {
-                settings.set_plugin_enabled (info.get_module_name (), false);
+                settings.set_plugin_enabled ("lib%s.so".printf (info.get_module_name ()), false);
             });
 
             var extensions = Plugins.get_default ().plug<AppActivatable> ("app", this);

--- a/core/plugins.vala
+++ b/core/plugins.vala
@@ -40,7 +40,7 @@ namespace Midori {
             foreach (var plugin in get_plugin_list ()) {
                 debug ("Found plugin %s", plugin.get_name ());
                 if (plugin.is_builtin ()
-                 || settings.get_plugin_enabled (plugin.get_module_name ())) {
+                 || settings.get_plugin_enabled ("lib%s.so".printf (plugin.get_module_name ()))) {
                     if (!try_load_plugin (plugin)) {
                         critical ("Failed to load plugin %s", plugin.get_module_name ());
                     }

--- a/core/settings.vala
+++ b/core/settings.vala
@@ -42,11 +42,11 @@ namespace Midori {
         }
 
         public bool get_plugin_enabled (string plugin) {
-            return get_boolean ("extensions", "lib%s.so".printf (plugin));
+            return get_boolean ("extensions", plugin);
         }
 
         public void set_plugin_enabled (string plugin, bool enabled) {
-            set_boolean ("extensions", "lib%s.so".printf (plugin), enabled);
+            set_boolean ("extensions", plugin, enabled);
         }
 
         public int last_window_width { get {


### PR DESCRIPTION
Since web extensions don't show up in the GUI yet this only covers reading `~/.config/midori/config` and looking for a key with the filename/folder of the extension on disk in `[extensions]` which can be set to `true` or `false' just like Peas-based plugins.