### PR TITLE
Prevent focus Urlbar when activating tab.

### DIFF
--- a/core/browser.vala
+++ b/core/browser.vala
@@ -437,7 +437,9 @@ namespace Midori {
         void goto_activated () {
             if (!tab.pinned) {
                 navigationbar.show ();
-                navigationbar.urlbar.grab_focus ();
+                if (navigationbar.urlbar.blank) {
+                    navigationbar.urlbar.grab_focus ();
+                }
             }
         }
 

--- a/core/urlbar.vala
+++ b/core/urlbar.vala
@@ -31,7 +31,7 @@ namespace Midori {
             _secure = value;
             update_icon ();
         } }
-        bool blank { get { return uri == "about:blank" || uri == "internal:speed-dial"; } }
+        internal bool blank { get { return uri == "about:blank" || uri == "internal:speed-dial"; } }
 
         [GtkChild]
         Gtk.Popover? suggestions;


### PR DESCRIPTION
Prevent focus Urlbar when activating tab, checks the url is not blank.