### PR TITLE
Add a snap job to CircleCI to verify snap build fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,18 @@ jobs:
         command: |
           cd _build
           make install
+  snap:
+    docker:
+    - image: cibuilds/snapcraft:stable
+    steps:
+    - checkout
+    - run:
+        name: Refresh package cache
+        command: |
+          apt-get update
+    - run:
+        name: Build snap
+        command: snapcraft
   android:
     docker:
     - image: circleci/android:api-28-alpha
@@ -61,4 +73,5 @@ workflows:
   ci:
     jobs:
     - build
+    - snap
     - android

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -72,10 +72,14 @@ parts:
       - libgcr-3-dev
       - libpeas-dev
       - libsqlite3-dev
+      - libjson-glib-dev
+      - libarchive-dev
       - intltool
       - ninja-build
       - libxml2-utils # xmllint
     stage-packages:
+      - libjson-glib-1.0-0
+      - libarchive13
       - libwebkit2gtk-4.0-37
       - libgcr-base-3-1
       - libgcr-ui-3-1


### PR DESCRIPTION
The snap build is broken since the no deps haven't been added - this should've been caught by CI.