### PR TITLE
Don't override Del if row can't be deleted

### DIFF
--- a/core/urlbar.vala
+++ b/core/urlbar.vala
@@ -106,11 +106,12 @@ namespace Midori {
                     case Gdk.Key.Delete:
                     case Gdk.Key.KP_Delete:
                         var suggestion_row = (SuggestionRow)selected_row;
-                        if (suggestion_row != null && !suggestion_row.item.database.readonly) {
+                        if (suggestion_row != null && suggestion_row.item.database != null && !suggestion_row.item.database.readonly) {
                             listbox.move_cursor (Gtk.MovementStep.DISPLAY_LINES, -1);
                             suggestion_row.item.delete.begin ();
+                            return true;
                         }
-                        return true;
+                        return base.key_press_event (event);
                     case Gdk.Key.Escape:
                         popdown ();
                         return true;


### PR DESCRIPTION
Handling of the Delete key with the suggestions popover visible
needs to fallback to the key press event (of the entry) if the
selected row can't be deleted.

The item should also be checked to be backed by a database.

Fixes: #269