### PR TITLE
Explicitly check for leading or trailing space in urlbar

### DIFF
--- a/core/urlbar.vala
+++ b/core/urlbar.vala
@@ -177,7 +177,8 @@ namespace Midori {
         }
 
         string? magic_uri (string text) {
-            if (" " in text) {
+            // Leading or trailing space means search
+            if (text.has_prefix (" ") || text.has_suffix (" ")) {
                 return null;
             } else if (Path.is_absolute (text)) {
                 try {


### PR DESCRIPTION
Otherwise eg. javascript: URLs with spaces don't work as expected