### PR TITLE
Release Midori 8.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ add_definitions("-DGETTEXT_PACKAGE=\"${GETTEXT_PACKAGE}\"")
 project(${GETTEXT_PACKAGE} C)
 set(PROJECT_BUGS https://github.com/midori-browser/core/issues)
 set(PROJECT_WEBSITE https://www.midori-browser.org)
-set(CORE_VERSION 7.0)
+set(CORE_VERSION 8.0)
 
 execute_process(COMMAND "git" "describe" "--tags"
                 OUTPUT_VARIABLE REVISION

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,17 @@
+v8.0
+ Javascript changes confirmation and prompts use dialogs again
+ Bug fixes in Urlbar completion and focus handling as well as Adblock filtering
+ Headerbar enabled by default only under Budgie, GNOME and Patreon
+ Re-introduced support for `--inactivity-reset`, `-e Fullscreen` and `-e ZoomIn`
+ Initial support for cross-browser web extensions (not exposed in the GUI yet)
+ Builds deps: Glib lowered to 2.46.2, Json-Glib and libarchive are now required
+ Link to the bug tracker from the About dialog
+ Correct handling of external URIs such as apt:
+ Fixed installation path for appdata and plugins
+ Support for building Midori on Android with Gradle
+ Better internal distinction of errors from visiting pages
+ Zoom indicators in the page menu and statusbar features extension
+
 v7.0
  Fixed YouTube rendering issue due to custom user agent
  Fixed invisible cursor in text fields

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![Telegram](https://img.shields.io/badge/Telegram-Chat-gray.svg?style=flat&logo=telegram&colorA=5583a4&logoColor=fff)](https://www.midori-browser.org/telegram)
 [![Twitter](https://img.shields.io/twitter/follow/midoriweb.svg?style=social&label=Follow)](https://twitter.com/midoriweb)
 [![Donate](https://img.shields.io/badge/PayPal-Donate-gray.svg?style=flat&logo=paypal&colorA=0071bb&logoColor=fff)](https://www.midori-browser.org/donate)
+[![BountySource](https://img.shields.io/bountysource/team/midori/activity.svg)](https://www.bountysource.com/teams/midori)
+[![Patreon](https://img.shields.io/badge/PATREON-Pledge-red.svg)](https://www.patreon.com/midoribrowser)
 
 <p align="center">
     <img src="icons/scalable/apps/midori.svg"/>
@@ -111,13 +113,16 @@ You'll want to **unit test** the code if you're testing a new version or contrib
 
 # Release process
 
-Update `CORE_VERSION` in `CMakeLists.txt` to `7.0`.
+We're on a 8/4 cycle which means 8 weeks of features and 4 weeks of stabilization
+capped at a release once every 3 months ie. at the last of the third month.
+
+Update `CORE_VERSION` in `CMakeLists.txt` to `8.0`.
 Add a section to `ChangeLog`.
 
-    git commit -p -v -m "Release Midori 7.0"
-    git checkout -B release-7.0
+    git commit -p -v -m "Release Midori 8.0"
+    git checkout -B release-8.0
     git push origin HEAD
-    git archive --prefix=midori-v7.0/ -o midori-v7.0.tar.gz -9 HEAD
+    git archive --prefix=midori-v8.0/ -o midori-v8.0.tar.gz -9 HEAD
 
 Propose a PR for the release.
 Publish the release on https://github.com/midori-browser/core/releases


### PR DESCRIPTION
- Bump to 8.0
- Updated `ChangeLog`
- Updated release steps in `README.md` to specify release cycle
- Updated `README.md` to include links to BountySource and Patreon

Fixes: #222