### PR TITLE
Removed focus timeout in the callback

### DIFF
--- a/core/browser.vala
+++ b/core/browser.vala
@@ -305,6 +305,7 @@ namespace Midori {
                         focus_timeout = 0;
                     }
                     focus_timeout = Timeout.add (500, () => {
+                        focus_timeout = 0;
                         tab.grab_focus ();
                         goto_activated ();
                         return Source.REMOVE;


### PR DESCRIPTION
(midori:24581): GLib-CRITICAL **: 15:48:51.069: Source ID 58 was not found when attempting to remove it

This is a possibly harmless warning that can be seen when switching tabs. Nevertheless it's obscuring logs.