### PR TITLE
Don't set empty tab title from history

### DIFF
--- a/core/tab.vala
+++ b/core/tab.vala
@@ -104,7 +104,9 @@ namespace Midori {
                 var history = HistoryDatabase.get_default (web_context.is_ephemeral ());
                 var item = yield history.lookup (display_uri);
                 if (item != null) {
-                    display_title = item.title;
+                    if (item.title != null && item.title != "") {
+                        display_title = item.title;
+                    }
                     this.item = item;
                 }
             } catch (DatabaseError error) {


### PR DESCRIPTION
Even though a tab was looked up in the history to re-use its
title without loading it, the title may be empty.

In that case don't set the empty saved title which would override
the URL being shown as a fallback.