### PR TITLE
Mention the Astian Foundation and authors in About

### DIFF
--- a/ui/about.ui
+++ b/ui/about.ui
@@ -2,7 +2,13 @@
   <template class="MidoriAbout" parent="GtkAboutDialog">
     <property name="modal">yes</property>
     <property name="logo-icon-name">midori</property>
-    <property name="copyright">2007-2019 Christian Dywan</property>
+    <property name="copyright" translatable="yes">2007-2019 Astian Foundation</property>
+    <property name="authors">2007-2019 Christian Dywan &lt;christian@twotoasts.de&gt;
+      2009-2012 Alexander Butenko &lt;a.butenka@gmail.com&gt;
+      2014 Paweł Forysiuk &lt;tuxator@o2.pl&gt;
+      2010 Samuel Creshal &lt;creshal@arcor.de&gt;
+      2010 Arno Renevier &lt;arno@renevier.net&gt;
+    </property>
     <property name="license-type">GTK_LICENSE_LGPL_2_1</property>
     <property name="program-name" translatable="yes">Midori Web Browser</property>
     <property name="comments" translatable="yes">A lightweight web browser.</property>


### PR DESCRIPTION
As an umbrella organization the Astian Foundation should appear in the About
dialog - legally speaking there is nor will there be copyright assignment.