### PR TITLE
Add Paste & Proceed in the urlbar

### DIFF
--- a/core/urlbar.vala
+++ b/core/urlbar.vala
@@ -276,6 +276,17 @@ namespace Midori {
             suggestions.grab_focus ();
         }
 
+        protected override void populate_popup (Gtk.Menu menu) {
+            string? text = Gtk.Clipboard.get_for_display (get_display (), Gdk.SELECTION_CLIPBOARD).wait_for_text ();
+            var menuitem = new Gtk.MenuItem.with_mnemonic ("Paste and p_roceed");
+            menuitem.sensitive = text != null;
+            menuitem.activate.connect (() => {
+                uri = magic_uri (text) ?? CoreSettings.get_default ().uri_for_search (text);
+            });
+            menuitem.show ();
+            menu.insert (menuitem, 3);
+        }
+
         void update_icon () {
             if (blank) {
                 primary_icon_name = null;


### PR DESCRIPTION
What this does is simple yet incredibly useful: copy text, which can be a URL or words for something to search online, and directly open it.

![Screenshot from 2019-04-21 22-48-56](https://user-images.githubusercontent.com/1204189/56475380-b580f200-6487-11e9-994d-6d64bb23a725.png)
