### PR TITLE
Use selected text as default for inline find

### DIFF
--- a/core/browser.vala
+++ b/core/browser.vala
@@ -602,6 +602,10 @@ namespace Midori {
         void find_activated () {
             search.show ();
             search.search_mode_enabled = true;
+            string? text = Gtk.Clipboard.get_for_display (get_display (), Gdk.SELECTION_PRIMARY).wait_for_text ();
+            if (text != null) {
+                search_entry.text = text.strip ();
+            }
             search_entry.grab_focus ();
         }
 


### PR DESCRIPTION
1. Select text
2. Start searching the page via ^F or the respective menu item
#. The selected text becomes the search text