### PR TITLE
Don't override focus_in_event to undelay tabs

### DIFF
--- a/core/browser.vala
+++ b/core/browser.vala
@@ -312,6 +312,9 @@ namespace Midori {
                     focus_timeout = Timeout.add (500, () => {
                         focus_timeout = 0;
                         tab.grab_focus ();
+                        if (tab.display_uri != tab.uri) {
+                            tab.load_uri (tab.display_uri);
+                        }
                         search_entry.text = tab.get_find_controller ().get_search_text () ?? "";
                         search.visible = search_entry.text != "";
                         search.search_mode_enabled = search.visible;

--- a/core/tab.vala
+++ b/core/tab.vala
@@ -114,14 +114,6 @@ namespace Midori {
             }
         }
 
-        public override bool focus_in_event (Gdk.EventFocus event) {
-            // Delayed load on focus
-            if (display_uri != uri) {
-                load_uri (display_uri);
-            }
-            return base.focus_in_event (event);
-        }
-
         void update_progress (ParamSpec pspec) {
             // Update back/ forward state here since there's no signal
             can_go_back = base.can_go_back ();


### PR DESCRIPTION
This seems to cause high CPU spikes while the view has focus.

Fixes: #323