### PR TITLE
Explicitly allow script windows and dialogs

### DIFF
--- a/core/browser.vala
+++ b/core/browser.vala
@@ -404,7 +404,7 @@ namespace Midori {
             get_size (out width, null);
             is_small = width < 500;
 
-            if (!(get_style_context ().has_class ("tiled") || is_maximized || is_fullscreen)) {
+            if (!(get_style_context ().has_class ("tiled") || is_maximized || is_fullscreen || is_locked)) {
                 int height;
                 get_size (null, out height);
                 var settings = CoreSettings.get_default ();
@@ -723,8 +723,21 @@ namespace Midori {
                 new_tab.hide ();
                 new_tab.ready_to_show.connect (() => {
                     new_tab.show ();
+                    if (!new_tab.get_window_properties ().locationbar_visible) {
+                        new_tab.pinned = true;
+                        var browser = new Browser ((App)application, true);
+                        var geometry = new_tab.get_window_properties ().geometry;
+                        browser.default_width = geometry.width > 1 ? geometry.width : 640;
+                        browser.default_height = geometry.height > 1 ? geometry.height : 480;
+                        browser.transient_for = this;
+                        browser.add (new_tab);
+                        browser.show ();
+                        return;
+                    }
+                    new_tab.set_data<bool> ("foreground", true);
                     add (new_tab);
                 });
+                new_tab.load_request (action.get_request ());
                 return new_tab;
             });
             tab.enter_fullscreen.connect (() => {

--- a/core/tab.vala
+++ b/core/tab.vala
@@ -71,6 +71,8 @@ namespace Midori {
             settings.user_agent += " %s".printf (Config.CORE_USER_AGENT_VERSION);
             bind_property ("pinned", settings, "enable-developer-extras", BindingFlags.SYNC_CREATE | BindingFlags.INVERT_BOOLEAN);
             var core_settings = CoreSettings.get_default ();
+            settings.javascript_can_open_windows_automatically = true;
+            settings.allow_modal_dialogs = true;
             settings.enable_javascript = core_settings.enable_javascript;
             core_settings.notify["enable-javascript"].connect ((pspec) => {
                 settings.enable_javascript = core_settings.enable_javascript;


### PR DESCRIPTION
- Allow scripts to "automatically" open windows and modal dialogs
- Open windows with no urlbar like apps (locked and pinned)
- Ensure other windows which open as tabs open in the foreground

The "dialogs" are skipped by session management since the browser
is locked in this case. Transiency ensures the window is placed
approprietely.

Fixes: #318