### PR TITLE
Fetch favicons for tallies directly from tabs

### DIFF
--- a/core/app.vala
+++ b/core/app.vala
@@ -293,6 +293,8 @@ namespace Midori {
             settings.notify["enable-spell-checking"].connect ((pspec) => {
                 context.set_spell_checking_enabled (settings.enable_spell_checking);
             });
+            // Enable the database by resetting the directory to the default
+            context.set_favicon_database_directory (null);
             context.get_cookie_manager ().set_accept_policy (
                 settings.first_party_cookies_only ? WebKit.CookieAcceptPolicy.NO_THIRD_PARTY : WebKit.CookieAcceptPolicy.ALWAYS);
             settings.notify["first-party-cookies-only"].connect ((pspec) => {

--- a/core/favicon.vala
+++ b/core/favicon.vala
@@ -11,6 +11,14 @@
 
 namespace Midori {
     public class Favicon : Gtk.Image {
+        public new Cairo.Surface? surface { set {
+            var image = (Cairo.ImageSurface)value;
+            var pixbuf = image != null ? Gdk.pixbuf_get_from_surface (image, 0, 0, image.get_width (), image.get_height ()) : null;
+            int _icon_size = icon_size;
+            gicon = pixbuf != null ? (Icon)scale_to_icon_size (pixbuf) : null;
+            icon_size = _icon_size;
+        } }
+
         string? _uri = null;
         public string? uri { get { return _uri; } set {
             // Reset icon without losing the size
@@ -22,24 +30,19 @@ namespace Midori {
             load_icon.begin ();
         } }
 
-        construct {
-            var database = WebKit.WebContext.get_default ().get_favicon_database ();
-            database.favicon_changed.connect ((page_uri, favicon_uri) => {
-                if (page_uri == uri) {
-                    load_icon.begin ();
-                }
-            });
-        }
-
+        WebKit.FaviconDatabase? database;
         async void load_icon (Cancellable? cancellable = null) {
-            var database = WebKit.WebContext.get_default ().get_favicon_database ();
+            if (database == null) {
+                database = WebKit.WebContext.get_default ().get_favicon_database ();
+                database.favicon_changed.connect ((page_uri, favicon_uri) => {
+                    if (page_uri == uri) {
+                        load_icon.begin ();
+                    }
+                });
+            }
+
             try {
-                var surface = yield database.get_favicon (uri, cancellable);
-                if (surface != null) {
-                    var image = (Cairo.ImageSurface)surface;
-                    var pixbuf = Gdk.pixbuf_get_from_surface (image, 0, 0, image.get_width (), image.get_height ());
-                    gicon = (Icon)scale_to_icon_size (pixbuf);
-                }
+                surface = yield database.get_favicon (uri, cancellable);
             } catch (Error error) {
                 debug ("Icon failed to load: %s", error.message);
             }

--- a/core/tally.vala
+++ b/core/tally.vala
@@ -52,6 +52,7 @@ namespace Midori {
                     title: tab.display_title,
                     tooltip_text: tab.display_title,
                     visible: tab.visible);
+            tab.bind_property ("favicon", favicon, "surface", BindingFlags.SYNC_CREATE);
             tab.bind_property ("display-uri", this, "uri");
             title = tab.display_title;
             tab.bind_property ("display-title", this, "title");
@@ -117,7 +118,6 @@ namespace Midori {
         }
 
         construct {
-            bind_property ("uri", favicon, "uri");
             bind_property ("title", caption, "label");
             add_events (Gdk.EventMask.ENTER_NOTIFY_MASK);
             add_events (Gdk.EventMask.LEAVE_NOTIFY_MASK);


### PR DESCRIPTION
This change enables the use of `Favicon` by just updating the surface (read: the icon) directly such as from the tab. This is more reliable because the database can be behind in loading images even when the icon is known and avoids the question of what context to get the icon from entirely.

Fixes: #207