### PR TITLE
(Re-)Store pinned state of tabs

### DIFF
--- a/core/tab.vala
+++ b/core/tab.vala
@@ -53,6 +53,12 @@ namespace Midori {
                     item.title = display_title;
                 }
             });
+            notify["pinned"].connect ((pspec) => {
+                // Undelay if needed
+                if (display_uri != uri) {
+                    load_uri (display_uri);
+                }
+            });
         }
 
         public Tab (Tab? related, WebKit.WebContext web_context,

--- a/data/tabby/Update2.sql
+++ b/data/tabby/Update2.sql
@@ -1,0 +1,1 @@
+ALTER TABLE tabs ADD pinned INTEGER DEFAULT 0;

--- a/gresource.xml
+++ b/gresource.xml
@@ -22,6 +22,7 @@
     <file compressed="true">data/history/Day.sql</file>
     <file compressed="true">data/tabby/Create.sql</file>
     <file compressed="true">data/tabby/Update1.sql</file>
+    <file compressed="true">data/tabby/Update2.sql</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/about.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/bookmarks-button.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/browser.ui</file>


### PR DESCRIPTION
The most interesting non-obvious detail here is that undelaying a pinned
tab after creating it didn't work with the previous code.

Fixes: #178