### PR TITLE
Add Trust button to the security details popover

### DIFF
--- a/core/urlbar.vala
+++ b/core/urlbar.vala
@@ -43,6 +43,8 @@ namespace Midori {
         [GtkChild]
         Gtk.Box security_box;
         [GtkChild]
+        Gtk.Button trust;
+        [GtkChild]
         Gtk.Label security_status;
         Gcr.CertificateWidget? details = null;
 
@@ -313,12 +315,19 @@ namespace Midori {
                     }
                     return true;
                 });
+                trust.clicked.connect (() => {
+                    var tab = ((Browser)get_toplevel ()).tab;
+                    tab.web_context.allow_tls_certificate_for_host (tab.tls, new Soup.URI (uri).host);
+                    security.hide ();
+                    tab.reload ();
+                });
 
                 // Insert widget here because Gtk.Builder won't recognize the type
                 details = new Gcr.CertificateWidget (null);
                 security_box.add (details);
             }
             details.visible = tls != null;
+            trust.visible = tls != null && !secure;
             details.certificate = certificate;
             security_status.visible = !secure;
             security.show ();

--- a/ui/urlbar.ui
+++ b/ui/urlbar.ui
@@ -22,6 +22,20 @@
             <property name="label" translatable="yes">Security unknown</property>
           </object>
         </child>
+        <child>
+          <object class="GtkActionBar">
+            <property name="visible">yes</property>
+            <child>
+              <object class="GtkButton" id="trust">
+                <property name="label" translatable="yes">_Trust this website</property>
+                <property name="use-underline">yes</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="pack-type">end</property>
+          </packing>
+        </child>
       </object>
     </child>
   </object>


### PR DESCRIPTION
If a certificate is available but considered invalid, the Trust button
shows up in the details popover accessible via the icon in the urlbar.
A temporary exception which is valid for the remainder of the session
is added for the specific certificate and host combination.

Note: No attempt is made to preserve the exception.

Fixes: #182

![Screenshot from 2019-06-30 22-54-03](https://user-images.githubusercontent.com/1204189/60402047-28929d00-9b8a-11e9-8ae1-97117a165b3c.png)
