### PR TITLE
Change metadata license to CC0-1.0 in appdata.xml

### DIFF
--- a/data/midori.appdata.xml.in
+++ b/data/midori.appdata.xml.in
@@ -3,7 +3,7 @@
 <component type="desktop">
   <id>org.midori_browser.Midori</id>
   <launchable type="desktop-id">org.midori_browser.Midori.desktop</launchable>
-  <metadata_license>LGPL-2.1-or-later</metadata_license>
+  <metadata_license>CC0-1.0</metadata_license>
   <project_license>LGPL-2.1-or-later</project_license>
   <_name>Midori Web Browser</_name>
   <categories>


### PR DESCRIPTION
Context: LGPL is not allowed in appdata. The file is basically trivially compiled data except for the description which is copied from elsewhere, so there doesn't seem to be a reason against using Creative Commons Zero here.