### PR TITLE
Use a background image for speed dials

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -47,6 +47,7 @@ add_custom_command(OUTPUT resources.c
                    --target ${CMAKE_CURRENT_BINARY_DIR}/resources.c
                    ${CMAKE_SOURCE_DIR}/gresource.xml
                    DEPENDS ${CMAKE_SOURCE_DIR}/gresource.xml
+                   DEPENDS ${CMAKE_SOURCE_DIR}/data/about.css
                    DEPENDS ${CMAKE_SOURCE_DIR}/data/gtk3.css
                    DEPENDS ${CMAKE_SOURCE_DIR}/data/web-extension-api.js
                    DEPENDS ${UI_FILES}

--- a/core/app.vala
+++ b/core/app.vala
@@ -187,12 +187,11 @@ namespace Midori {
                 foreach (var shortcut in shortcuts) {
                     index++;
                     content += """
-                        <div class="shortcut">
+                        <div class="shortcut" style="background-image: url('%s')">
                           <a href="%s" accesskey="%u">
-                            <img src="%s" />
                             <span class="title">%s</span>
                           </a>
-                        </div>""".printf (shortcut.uri, index, "favicon:///" + shortcut.uri, shortcut.title);
+                        </div>""".printf ("favicon:///" + shortcut.uri, shortcut.uri, index, shortcut.title);
                 }
                 string stylesheet = (string)resources_lookup_data ("/data/about.css",
                                                                     ResourceLookupFlags.NONE).get_data ();

--- a/data/about.css
+++ b/data/about.css
@@ -81,12 +81,16 @@ button {
 
 .shortcut {
     width: 27%;
-    max-width: 32%;
     height: 30%;
     margin: 1%;
-    display: inline-table;
+    background-repeat: no-repeat;
+    background-position: center;
+    display: inline-block;
     box-sizing: border-box;
     overflow: hidden;
+    border-radius: 12px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.12),
+                0 1px 2px rgba(0,0,0,0.24);
 }
 
 .shortcut a {
@@ -96,18 +100,7 @@ button {
     text-decoration: none;
 }
 
-.shortcut a img {
-    width: 50%;
-    height: 50%;
-    margin: auto;
-    margin-bottom: .5em;
-    display: block;
-    border-radius: 12px;
-    box-shadow: 0 1px 3px rgba(0,0,0,0.12),
-                0 1px 2px rgba(0,0,0,0.24);
-}
-
-.shortcut a:hover img {
+.shortcut:hover {
     box-shadow: 0 3px 5px rgba(0,0,0,0.24),
                 0 3px 4px rgba(0,0,0,0.48);
 }
@@ -118,7 +111,7 @@ button {
     text-align: center;
     text-overflow: ellipsis;
     word-wrap: nowrap;
-    max-height: 2em;
+    height: 20%;
     line-height: 1em;
     overflow: hidden;
     display: block;


### PR DESCRIPTION
This allows easier positioning without stretching.

Also move the box-shadow to the shortcut container to make sure
the hover effect applies to the whole area consistently.

Fixes: #206