### PR TITLE
Retrieve og:image for better shortcut icons

### DIFF
--- a/core/database.vala
+++ b/core/database.vala
@@ -231,7 +231,7 @@ namespace Midori {
                 return ":memory:";
             else if (!Path.is_absolute (path))
                 return Path.build_filename (Environment.get_user_config_dir (),
-                    Environment.get_prgname (), path);
+                    Config.PROJECT_NAME, path);
             return path;
         }
 

--- a/data/about.css
+++ b/data/about.css
@@ -86,12 +86,17 @@ button {
     margin: 1%;
     background-repeat: no-repeat;
     background-position: center;
+    background-size: cover;
     display: inline-block;
     box-sizing: border-box;
     overflow: hidden;
     border-radius: 12px;
     box-shadow: 0 1px 3px rgba(0,0,0,0.12),
                 0 1px 2px rgba(0,0,0,0.24);
+}
+/* Match style="background-image: url('favicon:///');" */
+.shortcut[style*='favicon'] {
+    background-size: auto;
 }
 
 .shortcut a {
@@ -108,14 +113,15 @@ button {
 
 .shortcut a .title {
     position: absolute;
-    bottom: 4px;
-    margin: 4px;
-    width: 90%;
+    bottom: 0;
+    padding: 1em 4px;
+    width: 100%;
+    background-color: #dedede;
     color: #222222;
     text-align: center;
     text-overflow: ellipsis;
     white-space: nowrap;
-    height: 2em;
+    height: 1em;
     line-height: 1em;
     overflow: hidden;
     display: block;

--- a/data/history/Update1.sql
+++ b/data/history/Update1.sql
@@ -1,0 +1,1 @@
+ALTER TABLE history ADD image TEXT;

--- a/gresource.xml
+++ b/gresource.xml
@@ -20,6 +20,7 @@
     <file compressed="true">data/bookmarks/Create.sql</file>
     <file compressed="true">data/history/Create.sql</file>
     <file compressed="true">data/history/Day.sql</file>
+    <file compressed="true">data/history/Update1.sql</file>
     <file compressed="true">data/tabby/Create.sql</file>
     <file compressed="true">data/tabby/Update1.sql</file>
     <file compressed="true">data/tabby/Update2.sql</file>

--- a/web/CMakeLists.txt
+++ b/web/CMakeLists.txt
@@ -15,11 +15,13 @@ foreach(UNIT_SRC ${EXTENSIONS})
         include(ValaPrecompile)
         vala_precompile(UNIT_SRC_C ${UNIT}
             ${UNIT_SRC}
+            ${CMAKE_SOURCE_DIR}/core/database.vala
+            ${CMAKE_SOURCE_DIR}/core/history.vala
             ${CMAKE_SOURCE_DIR}/core/loggable.vala
             ${CMAKE_SOURCE_DIR}/core/plugins.vala
             ${CMAKE_SOURCE_DIR}/core/settings.vala
         PACKAGES
-            libsoup-2.4 libpeas-1.0
+            libsoup-2.4 libpeas-1.0 sqlite3
         OPTIONS
             ${VALAFLAGS}
         CUSTOM_VAPIS

--- a/web/activatable.vala
+++ b/web/activatable.vala
@@ -13,6 +13,35 @@ Midori.Plugins? plugins;
 public void webkit_web_extension_initialize_with_user_data (WebKit.WebExtension extension, Variant user_data) {
     plugins = Midori.Plugins.get_default (user_data.get_string ());
     extension.page_created.connect ((page) => {
+        page.document_loaded.connect (() => {
+            try {
+                // cf. http://ogp.me
+                // Note: Some websites incorrectly use "name" instead of "property"
+                var image = page.get_dom_document ().query_selector ("meta[property=\"og:image\"],meta[name=\"og:image\"]");
+                var uri = image != null ? image.get_attribute ("content") : null;
+                if (uri == null) {
+                    // Fallback to high res apple-touch-icon or "shortcut icon"
+                    image = page.get_dom_document ().query_selector ("link[sizes=\"any\"],link[sizes=\"152x152\"],link[sizes=\"144x144\"]");
+                    uri = image != null ? image.get_attribute ("href") : null;
+                }
+                if (uri != null && uri != "") {
+                    // Relative URL
+                    if (!("://" in uri)) {
+                        var soup_uri = new Soup.URI (page.uri);
+                        soup_uri.set_path ("/" + uri);
+                        soup_uri.set_query (null);
+                        uri = soup_uri.to_string (false);
+                    }
+                    debug ("Found thumbnail for %s: %s", page.uri, uri);
+                    var history = Midori.HistoryDatabase.get_default ();
+                    history.prepare ("UPDATE %s SET image = :image WHERE uri = :uri".printf (history.table),
+                                     ":image", typeof (string), uri,
+                                     ":uri", typeof (string), page.uri).exec ();
+                }
+            } catch (Error error) {
+                debug ("Failed to locate thumbnail for %s: %s", page.uri, error.message);
+            }
+        });
         var extensions = plugins.plug<Peas.Activatable> ("object", page);
         extensions.extension_added.connect ((info, extension) => ((Peas.Activatable)extension).activate ());
         extensions.extension_removed.connect ((info, extension) => { ((Peas.Activatable)extension).deactivate (); });


### PR DESCRIPTION
- `og:image` is looked up in the DOM
- The history database stores the "image" of an item
- An image is preferred over a favicon in the speed dial
- Shortcuts with images cover(stretch) the whole element
- Favicons remain as a fallback and won't stretch to fit

Only URLs are looked up, stored in the database and used directly. This has the benefit of being able to rely on WebKit's cache instead of our own image management.

**Note:** Images will be fetched as web pages are visited. The speed dial will continue to show only favicons unless a web page as been visited at least once with the fix in place.