### PR TITLE
Use project domain for icon in about dialog

### DIFF
--- a/core/about.vala
+++ b/core/about.vala
@@ -14,6 +14,7 @@ namespace Midori {
     class About : Gtk.AboutDialog {
         public About (Gtk.Window parent) {
            Object (transient_for: parent,
+                   logo_icon_name: Config.PROJECT_DOMAIN,
                    website: Config.PROJECT_WEBSITE,
                    version: Config.CORE_VERSION);
            var report = add_button (_("_Report a Problem…"), Gtk.ResponseType.HELP) as Gtk.Button;

--- a/ui/about.ui
+++ b/ui/about.ui
@@ -1,7 +1,6 @@
 <interface>
   <template class="MidoriAbout" parent="GtkAboutDialog">
     <property name="modal">yes</property>
-    <property name="logo-icon-name">midori</property>
     <property name="copyright" translatable="yes">2007-2019 Astian Foundation</property>
     <property name="authors">2007-2019 Christian Dywan &lt;christian@twotoasts.de&gt;
       2009-2012 Alexander Butenko &lt;a.butenka@gmail.com&gt;


### PR DESCRIPTION
#343 introduced a minor visual regression by not updating the icon name used in the about dialog. Unless a theme which provides it is available no logo is visible.