### PR TITLE
Add a generic item for a custom search option

### DIFF
--- a/core/preferences.vala
+++ b/core/preferences.vala
@@ -115,6 +115,12 @@ namespace Midori {
             combo.append ("http://search.yahoo.com/search?p=", "Yahoo");
             combo.append ("http://www.google.com/search?q=%s", "Google");
             settings.bind_property ("location-entry-search", combo, "active-id", BindingFlags.SYNC_CREATE | BindingFlags.BIDIRECTIONAL);
+            // Generic item for custom search option
+            if (combo.get_active_text () == null) {
+                string hostname = new Soup.URI (settings.location_entry_search).host;
+                combo.append (settings.location_entry_search, hostname);
+                combo.active_id = settings.location_entry_search;
+            }
             box.add (combo);
             box.show_all ();
             add (_("Browsing"), box);


### PR DESCRIPTION
In the case where a search engine was manually added to the config file
or provided through distro defaults, the combo will display the
hostname.

Fixes: #211