### PR TITLE
Use a single query with a covering index for shortcuts

### DIFF
--- a/core/database.vala
+++ b/core/database.vala
@@ -443,7 +443,7 @@ namespace Midori {
         public async virtual List<DatabaseItem>? query (string? filter=null, int64 max_items=15, Cancellable? cancellable=null) throws DatabaseError {
             string where = filter != null ? "WHERE uri LIKE :filter OR title LIKE :filter" : "";
             string sqlcmd = """
-                SELECT rowid, uri, title, date, count () AS ct FROM %s
+                SELECT rowid, uri, title, date, count (uri) AS ct FROM %s
                 %s
                 GROUP BY uri
                 ORDER BY ct DESC LIMIT :limit

--- a/data/history/Update2.sql
+++ b/data/history/Update2.sql
@@ -1,0 +1,2 @@
+/* Covering index for shortcuts */
+CREATE UNIQUE INDEX speed_dial ON history (date, image, title, uri) WHERE image <> '';

--- a/gresource.xml
+++ b/gresource.xml
@@ -21,6 +21,7 @@
     <file compressed="true">data/history/Create.sql</file>
     <file compressed="true">data/history/Day.sql</file>
     <file compressed="true">data/history/Update1.sql</file>
+    <file compressed="true">data/history/Update2.sql</file>
     <file compressed="true">data/tabby/Create.sql</file>
     <file compressed="true">data/tabby/Update1.sql</file>
     <file compressed="true">data/tabby/Update2.sql</file>


### PR DESCRIPTION
The covering index allows the speed dial to be created faster. A customized query also avoids having to retrieve the images separately. Grouping by image solves the problem of multiple shortcuts for the same site.

Fixes: #354