### PR TITLE
Consistent focus and color for speed dial

### DIFF
--- a/core/browser.vala
+++ b/core/browser.vala
@@ -306,18 +306,23 @@ namespace Midori {
                     bindings.append (tab.bind_property ("pinned", toggle_fullscreen, "visible", BindingFlags.INVERT_BOOLEAN));
                     bindings.append (tab.bind_property ("pinned", navigationbar, "visible", BindingFlags.INVERT_BOOLEAN));
                     bindings.append (tab.bind_property ("zoom-level", this, "zoom-level", BindingFlags.SYNC_CREATE));
+                    if (navigationbar.urlbar.blank) {
+                        navigationbar.urlbar.grab_focus ();
+                    } else {
+                        tab.grab_focus ();
+                    }
                     if (focus_timeout > 0) {
                         Source.remove (focus_timeout);
                         focus_timeout = 0;
                     }
                     focus_timeout = Timeout.add (500, () => {
                         focus_timeout = 0;
-                        tab.grab_focus ();
+                        // Delayed load on focus
+                        if (tab.display_uri != tab.uri) {
+                            tab.load_uri (tab.display_uri);
+                        }
                         search_entry.text = tab.get_find_controller ().get_search_text () ?? "";
                         search.search_mode_enabled = search_entry.text != "";
-                        if (navigationbar.urlbar.blank) {
-                            navigationbar.urlbar.grab_focus ();
-                        }
                         return Source.REMOVE;
                     }, Priority.LOW);
                 } else {

--- a/core/tab.vala
+++ b/core/tab.vala
@@ -73,6 +73,10 @@ namespace Midori {
 
             Object (related_view: related, web_context: web_context, user_content_manager: content, visible: true);
 
+            var rgba = Gdk.RGBA ();
+            rgba.parse ("#dedede");
+            set_background_color (rgba);
+
             var settings = get_settings ();
             settings.user_agent += " %s".printf (Config.CORE_USER_AGENT_VERSION);
             bind_property ("pinned", settings, "enable-developer-extras", BindingFlags.SYNC_CREATE | BindingFlags.INVERT_BOOLEAN);
@@ -120,14 +124,6 @@ namespace Midori {
             } catch (DatabaseError error) {
                 debug ("Failed to lookup title in history: %s", error.message);
             }
-        }
-
-        public override bool focus_in_event (Gdk.EventFocus event) {
-            // Delayed load on focus
-            if (display_uri != uri) {
-                load_uri (display_uri);
-            }
-            return base.focus_in_event (event);
         }
 
         void update_progress (ParamSpec pspec) {

--- a/data/gtk3.css
+++ b/data/gtk3.css
@@ -107,3 +107,7 @@ statusbar button {
   margin: 0;
   padding: 0;
 }
+
+.tabs {
+  background-color: #dedede;
+}

--- a/ui/browser.ui
+++ b/ui/browser.ui
@@ -183,6 +183,9 @@
                         <property name="visible">yes</property>
                         <property name="hexpand">yes</property>
                         <property name="vexpand">yes</property>
+                        <style>
+                          <class name="tabs"/>
+                        </style>
                       </object>
                     </child>
                     <child type="overlay">


### PR DESCRIPTION
When opening the speed dial changes in background color and urlbar focus can be seen that make it feel a bit disruptive. This is due to the delay when switching tabs, the webview not being shown right away and the actual content being loaded after.

- Set the color of the "tabs" stack
- Set the webview's color to that of the speed dial
- Set focus between webview/ urlbar w/o delay
- Load tab without changing focus again