### PR TITLE
Removed "slash" ("/") as a hotkey for search

### DIFF
--- a/core/browser.vala
+++ b/core/browser.vala
@@ -121,7 +121,7 @@ namespace Midori {
                 application.set_accels_for_action ("win.tab-reopen", { "<Primary><Shift>t" });
                 application.set_accels_for_action ("win.fullscreen", { "F11" });
                 application.set_accels_for_action ("win.show-downloads", { "<Primary><Shift>j" });
-                application.set_accels_for_action ("win.find", { "<Primary>f", "slash" });
+                application.set_accels_for_action ("win.find", { "<Primary>f" });
                 application.set_accels_for_action ("win.view-source", { "<Primary>u", "<Primary><Alt>u" });
                 application.set_accels_for_action ("win.print", { "<Primary>p" });
                 application.set_accels_for_action ("win.caret-browsing", { "F7" });


### PR DESCRIPTION
Removed "slash" ("/") as a hotkey for search.
Consider adding Ctrl-S as a new hotkey, as Emacs uses this for search (instead of VI's slash ...)
Fixes: #364
