### PR TITLE
 Added special handling when Midori.Urlbar is in focus

### DIFF
--- a/core/browser.vala
+++ b/core/browser.vala
@@ -121,7 +121,7 @@ namespace Midori {
                 application.set_accels_for_action ("win.tab-reopen", { "<Primary><Shift>t" });
                 application.set_accels_for_action ("win.fullscreen", { "F11" });
                 application.set_accels_for_action ("win.show-downloads", { "<Primary><Shift>j" });
-                application.set_accels_for_action ("win.find", { "<Primary>f", "slash" });
+                application.set_accels_for_action ("win.find", { "<Primary>f" });
                 application.set_accels_for_action ("win.view-source", { "<Primary>u", "<Primary><Alt>u" });
                 application.set_accels_for_action ("win.print", { "<Primary>p" });
                 application.set_accels_for_action ("win.caret-browsing", { "F7" });

--- a/core/browser.vala
+++ b/core/browser.vala
@@ -121,7 +121,7 @@ namespace Midori {
                 application.set_accels_for_action ("win.tab-reopen", { "<Primary><Shift>t" });
                 application.set_accels_for_action ("win.fullscreen", { "F11" });
                 application.set_accels_for_action ("win.show-downloads", { "<Primary><Shift>j" });
-                application.set_accels_for_action ("win.find", { "<Primary>f" });
+                application.set_accels_for_action ("win.find", { "<Primary>f", "slash" });
                 application.set_accels_for_action ("win.view-source", { "<Primary>u", "<Primary><Alt>u" });
                 application.set_accels_for_action ("win.print", { "<Primary>p" });
                 application.set_accels_for_action ("win.caret-browsing", { "F7" });
@@ -453,6 +453,10 @@ namespace Midori {
             // No keyboard shortcuts in locked state
             if (is_locked) {
                 return propagate_key_event (event);
+            }
+			// Default behaviour for navigation bar
+            if (get_focus () is Midori.Urlbar) {
+                return navigationbar.urlbar.key_press_event (event);
             }
             // Default behavior for standard widgets
             if (!(get_focus () is WebKit.WebViewBase)) {

--- a/core/browser.vala
+++ b/core/browser.vala
@@ -457,8 +457,8 @@ namespace Midori {
 			// Default behaviour for navigation bar
             if (get_focus () is Midori.Urlbar) {
                 if (navigationbar.urlbar.key_press_event (event)) {
-					return true;
-				}
+                    return true;
+                }
             }
             // Default behavior for standard widgets
             if (!(get_focus () is WebKit.WebViewBase)) {

--- a/core/browser.vala
+++ b/core/browser.vala
@@ -456,7 +456,9 @@ namespace Midori {
             }
 			// Default behaviour for navigation bar
             if (get_focus () is Midori.Urlbar) {
-                return navigationbar.urlbar.key_press_event (event);
+                if (navigationbar.urlbar.key_press_event (event)) {
+					return true;
+				}
             }
             // Default behavior for standard widgets
             if (!(get_focus () is WebKit.WebViewBase)) {


### PR DESCRIPTION
This enables Ctrl-N and Ctrl-T again, as the edit field does not handle them.
Any key binding in the edit field takes precedence.
A thorough check of any side effects this may have is strongly recommended ...
Fixes: #364
