### PR TITLE
Transparently decode percent and punycode in URIs

### DIFF
--- a/core/suggestion-row.vala
+++ b/core/suggestion-row.vala
@@ -74,10 +74,22 @@ namespace Midori {
             return Markup.escape_text (text);
         }
 
-        string? strip_uri_prefix (string uri) {
+        internal static string unescape_uri (string uri) {
+            // Percent-decode and decode punycode for user display
+            string[] parts = uri.split ("://", 2);
+            if (parts != null && parts[0] != null && parts[1] != null) {
+                string[] path = parts[1].split ("/", 2);
+                if (path != null && path[0] != null && path[1] != null) {
+                    return parts[0] + "://" + Hostname.to_unicode (path[0]) + "/" + Uri.unescape_string (path[1]);
+                }
+            }
+            return uri;
+        }
+
+        internal static string strip_uri_prefix (string uri) {
             bool is_http = uri.has_prefix ("http://") || uri.has_prefix ("https://");
             if (is_http || uri.has_prefix ("file://")) {
-                string stripped_uri = uri.split ("://")[1];
+                string stripped_uri = unescape_uri (uri);
                 if (is_http && stripped_uri.has_prefix ("www."))
                     return stripped_uri.substring (4, -1);
                 return stripped_uri;

--- a/core/tab.vala
+++ b/core/tab.vala
@@ -214,7 +214,7 @@ namespace Midori {
             }
 
             var monitor = NetworkMonitor.get_default ();
-            string hostname = new Soup.URI (uri).host;
+            string hostname = Hostname.to_unicode (new Soup.URI (uri).host);
             string? title = null;
             string? message = null;
             if (!monitor.network_available) {
@@ -261,7 +261,7 @@ namespace Midori {
         }
 
         public override void mouse_target_changed (WebKit.HitTestResult result, uint modifiers) {
-            link_uri = result.link_uri;
+            link_uri = result.link_uri != null ? SuggestionRow.strip_uri_prefix (result.link_uri) : null;
         }
 
         public override bool context_menu (WebKit.ContextMenu menu,
@@ -348,11 +348,11 @@ namespace Midori {
                     break;
                 case WebKit.ScriptDialogType.CONFIRM:
                 case WebKit.ScriptDialogType.BEFORE_UNLOAD_CONFIRM:
-                    string hostname = new Soup.URI (uri).host;
+                    string hostname = Hostname.to_unicode (new Soup.URI (uri).host);
                     dialog.confirm_set_confirmed(((Browser)get_toplevel ()).prompt (hostname, dialog.get_message (), _("_Confirm")) != null);
                     break;
                 case WebKit.ScriptDialogType.PROMPT:
-                    string hostname = new Soup.URI (uri).host;
+                    string hostname = Hostname.to_unicode (new Soup.URI (uri).host);
                     dialog.prompt_set_text(((Browser)get_toplevel ()).prompt (hostname, dialog.get_message (), _("_Confirm"), dialog.prompt_get_default_text ()));
                     break;
             }
@@ -380,7 +380,7 @@ namespace Midori {
 
         public override bool permission_request (WebKit.PermissionRequest permission) {
             if (permission is WebKit.GeolocationPermissionRequest) {
-                string hostname = new Soup.URI (uri).host;
+                string hostname = Hostname.to_unicode (new Soup.URI (uri).host);
                 message.label = _("%s wants to know your location.").printf (hostname);
             } else if (permission is WebKit.NotificationPermissionRequest) {
                 permission.allow ();

--- a/core/urlbar.vala
+++ b/core/urlbar.vala
@@ -22,7 +22,7 @@ namespace Midori {
             _uri = value;
             location = value;
             // Treat about:blank specially
-            text = blank ? "" : value;
+            text = blank ? "" : SuggestionRow.unescape_uri (value);
             set_position (-1);
             update_icon ();
         } }


### PR DESCRIPTION
Unicode in two parts of a URL is usually encoded, the domain itself and the path. Those should be rendered in actual unicode to make them more user-friendly.

- The URL in the urlbar should appear decoded
- Punycode remains visible in the security popover(!)
- While hovering the statusbar, domain and path should be in unicode
- Error pages should use the unicode hostname
- Dialogs for permissions and scripts should use the unicode hostname

Examples:

- https://ja.wikipedia.org/wiki/アルマジロトカゲ (Armadillo girdled lizard)
- https://Яндекс.рф (Yandex)
- https://i❤tacos.ws/