### PR TITLE
Adblock filter list needs to be scrollable

### DIFF
--- a/extensions/adblock/extension.vala
+++ b/extensions/adblock/extension.vala
@@ -162,9 +162,15 @@ namespace Adblock {
                 Application.get_default ().open (files, "");
                 return true;
             });
-            listbox.insert (label, -1);
+            var vbox = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
+            vbox.pack_end (label, false, false);
 
-            box.add (listbox);
+            var scrolled = new Gtk.ScrolledWindow (null, null);
+            scrolled.hscrollbar_policy = Gtk.PolicyType.NEVER;
+            scrolled.min_content_height = 150;
+            scrolled.add (listbox);
+            vbox.pack_start (scrolled, true, true);
+            box.add (vbox);
             box.show_all ();
             preferences.add (_("Privacy"), box);
             deactivate.connect (() => {

--- a/extensions/adblock/subscription.vala
+++ b/extensions/adblock/subscription.vala
@@ -182,7 +182,7 @@ namespace Adblock {
             try {
                 yield parse (headers_only);
             } catch (Error error) {
-                critical ("Failed to parse %s%s: %s", headers_only ? "headers for " : "", uri, error.message);
+                debug ("Failed to parse %s%s: %s", headers_only ? "headers for " : "", uri, error.message);
             }
         }
 
@@ -218,6 +218,12 @@ namespace Adblock {
             string key = header;
             string value = "";
             if (header.contains (":")) {
+                // FIXME: Unsupported format
+                // !:partner_token=example.com
+                if (header.has_prefix ("!:")) {
+                    debug ("Unsupported header '%s'", header);
+                    return;
+                }
                 string[] parts = header.split (":", 2);
                 if (parts[0] != null && parts[0] != ""
                  && parts[1] != null && parts[1] != "") {


### PR DESCRIPTION
The list in the preferences dialog currently grows with each filter. It should instead scroll after exceeding a certain size.