### PR TITLE
Specify an action on notifications to activate the tab

### DIFF
--- a/core/app.vala
+++ b/core/app.vala
@@ -148,6 +148,10 @@ namespace Midori {
 
             add_action_entries (actions, this);
 
+            var tab_focus_action = new SimpleAction ("tab-focus", VariantType.STRING);
+            tab_focus_action.activate.connect (tab_focus_activated);
+            add_action (tab_focus_action);
+
             var action = new SimpleAction ("win-new", VariantType.STRING);
             action.activate.connect (win_new_activated);
             add_action (action);
@@ -366,6 +370,20 @@ namespace Midori {
                 critical ("Failed to render %s: %s", request.get_uri (), error.message);
             }
             request.unref ();
+        }
+
+        void tab_focus_activated (Action action, Variant? parameter) {
+            string id = parameter.get_string ();
+            foreach (var browser in get_windows ()) {
+                if (!(browser is Browser))
+                    continue;
+                foreach (var tab in ((Browser)browser).tabs.get_children ()) {
+                    if (((Tab)tab).id == id) {
+                        ((Browser)browser).tabs.visible_child = tab;
+                        browser.present ();
+                    }
+                }
+            }
         }
 
         void win_new_activated (Action action, Variant? parameter) {

--- a/core/tab.vala
+++ b/core/tab.vala
@@ -374,6 +374,7 @@ namespace Midori {
             notification.set_body (webkit_notification.body);
             // Use a per-host ID to avoid collisions, but neglect the tag
             string hostname = new Soup.URI (uri).host;
+            notification.set_default_action_and_target_value("app.tab-focus", id);
             Application.get_default ().send_notification ("web-%s".printf (hostname), notification);
             return true;
         }


### PR DESCRIPTION
By default GTK just activates the app which in practice opens a new
window instead of focussing the original one.

Fixes: #381