### PR TITLE
fixes #409 cannot enter '/' in urlbar

### DIFF
--- a/core/browser.vala
+++ b/core/browser.vala
@@ -121,7 +121,7 @@ namespace Midori {
                 application.set_accels_for_action ("win.tab-reopen", { "<Primary><Shift>t" });
                 application.set_accels_for_action ("win.fullscreen", { "F11" });
                 application.set_accels_for_action ("win.show-downloads", { "<Primary><Shift>j" });
-                application.set_accels_for_action ("win.find", { "<Primary>f", "slash" });
+                application.set_accels_for_action ("win.find", { "<Primary>f" });
                 application.set_accels_for_action ("win.view-source", { "<Primary>u", "<Primary><Alt>u" });
                 application.set_accels_for_action ("win.print", { "<Primary>p" });
                 application.set_accels_for_action ("win.caret-browsing", { "F7" });


### PR DESCRIPTION
Unfortunately the "cannot enter slash in url bar" bug still exists in the current version. This pull request fixed it for me.