### PR TITLE
Name fix: official spelling is "DuckDuckGo".

### DIFF
--- a/core/preferences.vala
+++ b/core/preferences.vala
@@ -111,7 +111,7 @@ namespace Midori {
 
             box = new LabelWidget (_("Search _with"));
             var combo = new Gtk.ComboBoxText ();
-            combo.append ("https://duckduckgo.com/?q=%s", "Duck Duck Go");
+            combo.append ("https://duckduckgo.com/?q=%s", "DuckDuckGo");
             combo.append ("http://search.yahoo.com/search?p=", "Yahoo");
             combo.append ("http://www.google.com/search?q=%s", "Google");
             settings.bind_property ("location-entry-search", combo, "active-id", BindingFlags.SYNC_CREATE | BindingFlags.BIDIRECTIONAL);


### PR DESCRIPTION
Single, one-line change to code, as the official spelling of the website is "DuckDuckGo"